### PR TITLE
Add global search across all gear categories

### DIFF
--- a/src/components/GearPanel.js
+++ b/src/components/GearPanel.js
@@ -38,6 +38,12 @@ export default function GearPanel(props) {
   const [NewGearDesc, setNewGearDesc]   = useState('');
   const [SelectedGear, setSelectedGear] = useState(props.Gear);
   const [SelectedGearCategory, setSelectedGearCategory] = useState(GearCategories[0]);
+  const [globalSearch, setGlobalSearch] = useState('');
+
+  // Flat list of every item across all categories, with _category attached
+  const flatGearList = GearCategories.flatMap(cat =>
+    (GearData[cat]?.entries ?? []).map(item => ({ ...item, _category: cat }))
+  );
 
     const getSortedEntries = () =>
       GearData[SelectedGearCategory].entries.slice().sort((a, b) => a.Name.localeCompare(b.Name));
@@ -50,12 +56,15 @@ export default function GearPanel(props) {
     }
 
     const handleGearChange = (event) => {
-      const TempGear = getSortedEntries()[event.target.value];
+      const TempGear = globalSearch.length >= 2
+        ? flatGearList[event.target.value]
+        : getSortedEntries()[event.target.value];
       setNewGear(TempGear);
       setNewGearIndex(event.target.value);
-      setNewGearCost(TempGear.Cost);
+      setNewGearCost(TempGear.Cost ?? TempGear['$Cost'] ?? '0');
       setNewGearAmount(1);
       setNewGearDesc(TempGear.Notes ?? '');
+      if (TempGear._category) setSelectedGearCategory(TempGear._category);
     }
   
     const handleAddGear = () => {
@@ -96,28 +105,59 @@ export default function GearPanel(props) {
     </Box>
     <br></br>
 
-    <Box sx={{ width: '250px' }}>
-        <FormControl style={{'width':'200px'}}>
-            <InputLabel  id="gear-label">Gear Categories</InputLabel>
-            <NativeSelect
-                id="gear-dropdown"
-                value={SelectedGearCategory}
-                onChange={handleGearCategoryChange}>
-                {GearCategories.map(catName => (
-                    <option key={catName} value={catName}>{catName}</option>
-                ))}
-            </NativeSelect>
-        </FormControl>
-    </Box><br></br>
-    {SelectedGearCategory && (
+    <TextField
+      label="Search all gear"
+      placeholder="Type to search across all categories..."
+      value={globalSearch}
+      onChange={(e) => { setGlobalSearch(e.target.value); setNewGear(null); setNewGearIndex(0); }}
+      size="small"
+      style={{ width: '400px', marginBottom: '12px' }}
+    />
+
+    {globalSearch.length >= 2 ? (
       <SearchableSelect
-        items={getSortedEntries()}
+        items={flatGearList}
         value={NewGearIndex}
         onChange={handleGearChange}
-        label={SelectedGearCategory}
-        renderItem={renderGearItem}
+        label="All Gear"
+        getLabel={(item) => `${item.Name} (${item._category})`}
+        renderItem={(item, originalIndex) => {
+          const allowed = props.Edition !== 'SR3' || !item.BookPage || props.BooksFilter.includes(item.BookPage.split('.')[0]);
+          const bookCode = item.BookPage?.split('.')[0];
+          return (
+            <FilteredMenuItem allowed={allowed} bookCode={bookCode} key={originalIndex} value={originalIndex}>
+              {item.Name} <span style={{ opacity: 0.55, fontSize: '0.8em' }}>({item._category})</span>
+            </FilteredMenuItem>
+          );
+        }}
         style={{ minWidth: 650 }}
       />
+    ) : (
+      <>
+        <Box sx={{ width: '250px' }}>
+          <FormControl style={{ width: '200px' }}>
+            <InputLabel id="gear-label">Gear Categories</InputLabel>
+            <NativeSelect
+              id="gear-dropdown"
+              value={SelectedGearCategory}
+              onChange={handleGearCategoryChange}>
+              {GearCategories.map(catName => (
+                <option key={catName} value={catName}>{catName}</option>
+              ))}
+            </NativeSelect>
+          </FormControl>
+        </Box><br />
+        {SelectedGearCategory && (
+          <SearchableSelect
+            items={getSortedEntries()}
+            value={NewGearIndex}
+            onChange={handleGearChange}
+            label={SelectedGearCategory}
+            renderItem={renderGearItem}
+            style={{ minWidth: 650 }}
+          />
+        )}
+      </>
     )}
     {NewGear && (
         <>


### PR DESCRIPTION
Users previously had to know which category an item lived in before they could find it. Now a search field above the category picker searches across every category at once, showing results with their category name in parentheses (e.g. "Remote Control Deck Rating [1] (Stuff With Ratings)").

- Built flatGearList from all categories with _category attached to each item
- Search activates at 2+ characters, replacing the category dropdown with a flat cross-category SearchableSelect
- Results show category name in muted text alongside the item name
- Book filter still applied in global search mode (SR3)
- Selecting an item in global mode sets SelectedGearCategory so Add Gear works correctly
- Clearing the search restores the normal category + dropdown flow unchanged