### PR TITLE
Add CI workflow to gate PRs and deploys with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test --watchAll=false --ci --passWithNoTests
+
+      - name: Build
+        run: DISABLE_ESLINT_PLUGIN=true yarn build

--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -13,17 +13,21 @@ jobs:
       # Clone the repo
       - name: Clone repository
         uses: actions/checkout@v4
-      # Cache node modules
-      - name: Cache node modules
-        uses: actions/cache@v4
+      # Pin Node version and cache yarn deps
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          path: node_modules
-          key: yarn-deps-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            yarn-deps-${{ hashFiles('yarn.lock') }}
+          node-version: '20'
+          cache: 'yarn'
+      # Install dependencies
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      # Run tests before building — fail fast if anything is broken
+      - name: Run tests
+        run: yarn test --watchAll=false --ci --passWithNoTests
       # Build the static site
       - name: Create static build
-        run: yarn install && DISABLE_ESLINT_PLUGIN=true yarn build
+        run: DISABLE_ESLINT_PLUGIN=true yarn build
       # Upload the artifact for other stages to use
       - name: Share artifact in github workflow
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- New ci.yml runs on every PR to main and every push to feature branches: installs deps, runs Jest, builds with Vite. Blocks merge if anything fails.
- push_to_s3.yml updated: pins Node 20, uses yarn --frozen-lockfile, and runs tests before building. Deploy job only runs if build+test pass.