### PR TITLE
Add Edges & Flaws system, Otaku Submersion/Tribe, Cloud Save modal, Companion stat fixes

### DIFF
--- a/src/components/AttributesPanel.js
+++ b/src/components/AttributesPanel.js
@@ -115,6 +115,32 @@ export default function AttributesPanel(props) {
                         "max":9
                     }
                 },
+                "Giants":{
+                    "Body":{
+                        "limit":10,
+                        "max":13
+                    },
+                    "Quickness":{
+                        "limit":4,
+                        "max":7
+                    },
+                    "Strength":{
+                        "limit":9,
+                        "max":12
+                    },
+                    "Charisma":{
+                        "limit":2,
+                        "max":5
+                    },
+                    "Intelligence":{
+                        "limit":4,
+                        "max":7
+                    },
+                    "Willpower":{
+                        "limit":6,
+                        "max":9
+                    }
+                },
                 "Menehune":{
                     "Body":{
                         "limit":8,
@@ -608,6 +634,32 @@ export default function AttributesPanel(props) {
                     "Charisma":{
                         "limit":6,
                         "max":9
+                    },
+                    "Intelligence":{
+                        "limit":4,
+                        "max":7
+                    },
+                    "Willpower":{
+                        "limit":6,
+                        "max":9
+                    }
+                },
+                "Giants":{
+                    "Body":{
+                        "limit":10,
+                        "max":13
+                    },
+                    "Quickness":{
+                        "limit":4,
+                        "max":7
+                    },
+                    "Strength":{
+                        "limit":9,
+                        "max":12
+                    },
+                    "Charisma":{
+                        "limit":2,
+                        "max":5
                     },
                     "Intelligence":{
                         "limit":4,

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -5,6 +5,7 @@ import Tab from "@mui/material/Tab";
 import Box from "@mui/material/Box";
 import PriorityPanel from "./PriorityPanel";
 import PointBuyPanel from "./PointBuyPanel";
+import EdgesFlawsPanel from "./EdgesFlawsPanel";
 import IdentityPanel from "./IdentityPanel";
 import AttributesPanel from "./AttributesPanel";
 import SR2SkillsPanel from "./SR2SkillsPanel";
@@ -206,6 +207,8 @@ export default function BasicTabs() {
     log: [],
     description: "",
     notes: "",
+    edges: [],
+    flaws: [],
   };
   const [Edition, setEdition] = React.useState("SR2");
   const [CGMethod, setCGMethod] = React.useState('priorities');
@@ -430,7 +433,7 @@ export default function BasicTabs() {
     }
   };
 
-  const tabNames = ['Identity','Priorities','Attributes','Skills','Magic/Otaku','Cyberware','Gear','Decking','Vehicles','Contacts','Karma','Sheet'];
+  const tabNames = ['Identity','Priorities','Edges & Flaws','Attributes','Skills','Magic/Otaku','Cyberware','Gear','Decking','Vehicles','Contacts','Karma','Sheet'];
   const handleChange = (event, newValue) => {
     setValue(newValue);
     trackTabChanged(tabNames[newValue] ?? `Tab ${newValue}`);
@@ -672,21 +675,22 @@ export default function BasicTabs() {
             :
              <Tab label="Point Buy" {...a11yProps(1)} />
             }
-            <Tab label="Attributes" {...a11yProps(2)} />
-            <Tab label="Skills" {...a11yProps(3)} />
-            
-            {(Character.isOtaku) ? 
-            <Tab label="Otaku" {...a11yProps(4)} />
+            <Tab label="Edges &amp; Flaws" {...a11yProps(2)} />
+            <Tab label="Attributes" {...a11yProps(3)} />
+            <Tab label="Skills" {...a11yProps(4)} />
+
+            {(Character.isOtaku) ?
+            <Tab label="Otaku" {...a11yProps(5)} />
             :
-            <Tab label="Magic" {...a11yProps(4)} /> }
-            
-            <Tab label="Cyberware" {...a11yProps(5)} />
-            <Tab label="Gear" {...a11yProps(6)} />
-            <Tab label="Decking" {...a11yProps(7)} />
-            <Tab label="Vehicles" {...a11yProps(8)} />
-            <Tab label="Contacts" {...a11yProps(9)} />
-            <Tab label="Karma" {...a11yProps(10)} />
-            <Tab label="Sheet Display" {...a11yProps(11)} />
+            <Tab label="Magic" {...a11yProps(5)} /> }
+
+            <Tab label="Cyberware" {...a11yProps(6)} />
+            <Tab label="Gear" {...a11yProps(7)} />
+            <Tab label="Decking" {...a11yProps(8)} />
+            <Tab label="Vehicles" {...a11yProps(9)} />
+            <Tab label="Contacts" {...a11yProps(10)} />
+            <Tab label="Karma" {...a11yProps(11)} />
+            <Tab label="Sheet Display" {...a11yProps(12)} />
           </Tabs>
 
         </Box>
@@ -775,6 +779,16 @@ export default function BasicTabs() {
         </CustomTabPanel>
 
         <CustomTabPanel value={value} index={2}>
+          <EdgesFlawsPanel
+            edges={Character.edges ?? []}
+            flaws={Character.flaws ?? []}
+            cgmethod={Character.cgmethod}
+            onChangeEdges={(edges) => setCharacter({ ...Character, edges })}
+            onChangeFlaws={(flaws) => setCharacter({ ...Character, flaws })}
+          />
+        </CustomTabPanel>
+
+        <CustomTabPanel value={value} index={3}>
           <AttributesPanel
             ChangeAttributes={handleAttributesChange}
             currentCharacter={Character}
@@ -786,10 +800,10 @@ export default function BasicTabs() {
             Log={Character.log}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={3}>
+        <CustomTabPanel value={value} index={4}>
           {SkillsPanelRender(Edition)}
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={4}>
+        <CustomTabPanel value={value} index={5}>
           {(Character.isOtaku) ? 
           <OtakuPanel
             Edition={Edition}
@@ -849,7 +863,7 @@ export default function BasicTabs() {
           />
         }
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={5}>
+        <CustomTabPanel value={value} index={6}>
           <CyberwarePanel
             CashOnHand={Character.chargenCash}
             Cyberware={Character.cyberware}
@@ -869,7 +883,7 @@ export default function BasicTabs() {
             BooksFilter={Character.allowedBooks}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={6}>
+        <CustomTabPanel value={value} index={7}>
           <GearPanel
             Gear={Character.gear}
             Edition={Edition}
@@ -878,7 +892,7 @@ export default function BasicTabs() {
             BooksFilter={Character.allowedBooks}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={7}>
+        <CustomTabPanel value={value} index={8}>
           <DeckingPanel
             Decks={Character.decks}
             Agents={Character.agents}
@@ -893,7 +907,7 @@ export default function BasicTabs() {
             BooksFilter={Character.allowedBooks}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={8}>
+        <CustomTabPanel value={value} index={9}>
           <VehiclesPanel
             Vehicles={Character.vehicles}
             Drones={Character.drones}
@@ -909,14 +923,14 @@ export default function BasicTabs() {
             BooksFilter={Character.allowedBooks}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={9}>
+        <CustomTabPanel value={value} index={10}>
           <ContactsPanel
             onChangeCash={(cash) => setCharacter({ ...Character, cash: cash })}
             updateContacts={handleContactsUpdate}
             Contacts={Character.contacts}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={10}>
+        <CustomTabPanel value={value} index={11}>
           <KarmaDisplay
             onFinalization={(step) => {
               setCharacter({ ...Character, step: step });
@@ -939,7 +953,7 @@ export default function BasicTabs() {
             Log={Character.log}
           />
         </CustomTabPanel>
-        <CustomTabPanel value={value} index={11}>
+        <CustomTabPanel value={value} index={12}>
           <SheetDisplay
             onChangeStreetName={(name) =>
               setCharacter({ ...Character, street_name: name })

--- a/src/components/EdgesFlawsPanel.js
+++ b/src/components/EdgesFlawsPanel.js
@@ -1,0 +1,414 @@
+import React, { useState } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import TextField from "@mui/material/TextField";
+import Paper from "@mui/material/Paper";
+import Divider from "@mui/material/Divider";
+import Alert from "@mui/material/Alert";
+
+import EdgesFlawsData from "../data/SR3/EdgesAndFlaws.json";
+
+const MAX_EDGES = 5;
+const MAX_FLAWS = 5;
+const MAX_POINTBUY_BP = 6;
+
+// Returns the point value for an item given its selection (which may include a chosen cost option)
+function getItemCost(item, chosenCost) {
+  if (item.costOptions) return chosenCost ?? item.costOptions[0].value;
+  return item.cost;
+}
+
+function findDefinition(id, type) {
+  return (type === "edge" ? EdgesFlawsData.edges : EdgesFlawsData.flaws).find(
+    (x) => x.id === id
+  );
+}
+
+function CostBadge({ value }) {
+  const display = value > 0 ? `+${value}` : `${value}`;
+  return (
+    <Chip
+      label={display}
+      size="small"
+      color={value > 0 ? "success" : "error"}
+      sx={{ fontWeight: "bold", minWidth: 42 }}
+    />
+  );
+}
+
+function ItemPicker({ type, selectedItems, onAdd, cgmethod }) {
+  const pool = type === "edge" ? EdgesFlawsData.edges : EdgesFlawsData.flaws;
+  const [selectedId, setSelectedId] = useState("");
+  const [chosenCost, setChosenCost] = useState(null);
+  const [userInput, setUserInput] = useState("");
+
+  const currentDef = pool.find((x) => x.id === selectedId);
+
+  const handleSelectChange = (id) => {
+    setSelectedId(id);
+    setChosenCost(null);
+    setUserInput("");
+  };
+
+  const handleAdd = () => {
+    if (!selectedId) return;
+    const def = pool.find((x) => x.id === selectedId);
+    const cost = getItemCost(def, chosenCost);
+    onAdd({ id: selectedId, cost, note: userInput || undefined });
+    setSelectedId("");
+    setChosenCost(null);
+    setUserInput("");
+  };
+
+  const atMax =
+    selectedItems.filter((x) => x.type === type).length >= MAX_EDGES;
+
+  const label = type === "edge" ? "Edge" : "Flaw";
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, alignItems: "flex-end" }}>
+      <FormControl size="small" sx={{ minWidth: 220 }}>
+        <InputLabel>Add {label}</InputLabel>
+        <Select
+          value={selectedId}
+          label={`Add ${label}`}
+          onChange={(e) => handleSelectChange(e.target.value)}
+        >
+          <MenuItem value="">— choose —</MenuItem>
+          {pool.map((item) => {
+            const baseCost = item.costOptions
+              ? `${item.costOptions[0].value}…`
+              : item.cost;
+            return (
+              <MenuItem key={item.id} value={item.id}>
+                {item.name} ({baseCost > 0 ? `+${baseCost}` : baseCost})
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </FormControl>
+
+      {currentDef?.costOptions && (
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <InputLabel>Level</InputLabel>
+          <Select
+            value={chosenCost ?? ""}
+            label="Level"
+            onChange={(e) => setChosenCost(Number(e.target.value))}
+          >
+            {currentDef.costOptions.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label} ({opt.value > 0 ? `+${opt.value}` : opt.value})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      {currentDef?.userInput && (
+        <TextField
+          size="small"
+          label={currentDef.userInput}
+          value={userInput}
+          onChange={(e) => setUserInput(e.target.value)}
+          sx={{ minWidth: 160 }}
+        />
+      )}
+
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={handleAdd}
+        disabled={
+          !selectedId ||
+          (currentDef?.costOptions && chosenCost === null) ||
+          atMax
+        }
+      >
+        Add {label}
+      </Button>
+    </Box>
+  );
+}
+
+export default function EdgesFlawsPanel(props) {
+  const { edges, flaws, cgmethod, onChangeEdges, onChangeFlaws } = props;
+
+  const edgeCount = edges.length;
+  const flawCount = flaws.length;
+
+  const edgeBP = edges.reduce((sum, e) => sum + e.cost, 0);
+  const flawBP = flaws.reduce((sum, f) => sum + f.cost, 0);
+  const netBP = edgeBP + flawBP; // flaws are negative, so net = edges - |flaws|
+
+  const isPriority = cgmethod === "priorities";
+
+  let balanceValid = true;
+  let balanceMessage = "";
+  if (isPriority) {
+    if (netBP !== 0) {
+      balanceValid = false;
+      balanceMessage = `In Priority creation, Edges and Flaws must net to 0 BP. Current net: ${netBP > 0 ? "+" : ""}${netBP} BP.`;
+    }
+  } else {
+    // Point Buy: can spend up to 6 BP on edges (gaining from flaws) or gain up to 6 BP from flaws
+    if (netBP > MAX_POINTBUY_BP) {
+      balanceValid = false;
+      balanceMessage = `Edges exceed Flaws by ${netBP} BP. Max net spend in Point Buy is ${MAX_POINTBUY_BP} BP.`;
+    } else if (netBP < -MAX_POINTBUY_BP) {
+      balanceValid = false;
+      balanceMessage = `Flaws exceed Edges by ${Math.abs(netBP)} BP. Max net gain in Point Buy is ${MAX_POINTBUY_BP} BP.`;
+    }
+  }
+
+  const handleAddEdge = (item) => {
+    const def = findDefinition(item.id, "edge");
+    onChangeEdges([...edges, { ...item, type: "edge", name: def.name }]);
+  };
+
+  const handleAddFlaw = (item) => {
+    const def = findDefinition(item.id, "flaw");
+    onChangeFlaws([...flaws, { ...item, type: "flaw", name: def.name }]);
+  };
+
+  const handleRemoveEdge = (index) => {
+    onChangeEdges(edges.filter((_, i) => i !== index));
+  };
+
+  const handleRemoveFlaw = (index) => {
+    onChangeFlaws(flaws.filter((_, i) => i !== index));
+  };
+
+  const categories = [
+    "Attributes",
+    "Skills",
+    "Physical",
+    "Mental",
+    "Social",
+    "Magical",
+    "Matrix",
+    "Miscellaneous",
+  ];
+
+  return (
+    <Box sx={{ p: 2, maxWidth: 900 }}>
+      <Typography variant="h5" gutterBottom>
+        Edges &amp; Flaws
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Max 5 Edges and 5 Flaws.{" "}
+        {isPriority
+          ? "In Priority creation, total BP must net to zero."
+          : `In Point Buy, net spend/gain is capped at ${MAX_POINTBUY_BP} BP.`}
+      </Typography>
+
+      {/* Balance summary */}
+      <Paper
+        variant="outlined"
+        sx={{ p: 1.5, mb: 2, display: "flex", gap: 3, flexWrap: "wrap", alignItems: "center" }}
+      >
+        <Box>
+          <Typography variant="caption" color="text.secondary">
+            Edges
+          </Typography>
+          <Typography variant="body1" fontWeight="bold">
+            {edgeCount} / {MAX_EDGES} ({edgeBP > 0 ? "+" : ""}{edgeBP} BP)
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="caption" color="text.secondary">
+            Flaws
+          </Typography>
+          <Typography variant="body1" fontWeight="bold">
+            {flawCount} / {MAX_FLAWS} ({flawBP} BP)
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="caption" color="text.secondary">
+            Net
+          </Typography>
+          <Typography
+            variant="body1"
+            fontWeight="bold"
+            color={balanceValid ? "success.main" : "error.main"}
+          >
+            {netBP > 0 ? "+" : ""}{netBP} BP
+          </Typography>
+        </Box>
+        {!balanceValid && (
+          <Alert severity="warning" sx={{ flex: 1 }}>
+            {balanceMessage}
+          </Alert>
+        )}
+      </Paper>
+
+      {/* Selected Edges */}
+      <Typography variant="h6" gutterBottom>
+        Selected Edges
+      </Typography>
+      {edges.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          No edges selected.
+        </Typography>
+      ) : (
+        <Box sx={{ mb: 1 }}>
+          {edges.map((e, i) => {
+            const def = findDefinition(e.id, "edge");
+            return (
+              <Paper
+                key={i}
+                variant="outlined"
+                sx={{
+                  p: 1,
+                  mb: 0.5,
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 1,
+                }}
+              >
+                <CostBadge value={e.cost} />
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="body2" fontWeight="bold">
+                    {e.name}
+                    {e.note ? ` (${e.note})` : ""}
+                  </Typography>
+                  {def && (
+                    <Typography variant="caption" color="text.secondary">
+                      {def.description}
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={() => handleRemoveEdge(i)}
+                >
+                  Remove
+                </Button>
+              </Paper>
+            );
+          })}
+        </Box>
+      )}
+
+      {edges.length < MAX_EDGES && (
+        <Box sx={{ mb: 2 }}>
+          <ItemPicker
+            type="edge"
+            selectedItems={edges}
+            onAdd={handleAddEdge}
+            cgmethod={cgmethod}
+          />
+        </Box>
+      )}
+
+      <Divider sx={{ my: 2 }} />
+
+      {/* Selected Flaws */}
+      <Typography variant="h6" gutterBottom>
+        Selected Flaws
+      </Typography>
+      {flaws.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          No flaws selected.
+        </Typography>
+      ) : (
+        <Box sx={{ mb: 1 }}>
+          {flaws.map((f, i) => {
+            const def = findDefinition(f.id, "flaw");
+            return (
+              <Paper
+                key={i}
+                variant="outlined"
+                sx={{
+                  p: 1,
+                  mb: 0.5,
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: 1,
+                }}
+              >
+                <CostBadge value={f.cost} />
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="body2" fontWeight="bold">
+                    {f.name}
+                    {f.note ? ` (${f.note})` : ""}
+                  </Typography>
+                  {def && (
+                    <Typography variant="caption" color="text.secondary">
+                      {def.description}
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={() => handleRemoveFlaw(i)}
+                >
+                  Remove
+                </Button>
+              </Paper>
+            );
+          })}
+        </Box>
+      )}
+
+      {flaws.length < MAX_FLAWS && (
+        <Box sx={{ mb: 2 }}>
+          <ItemPicker
+            type="flaw"
+            selectedItems={flaws}
+            onAdd={handleAddFlaw}
+            cgmethod={cgmethod}
+          />
+        </Box>
+      )}
+
+      {/* Browse all Edges & Flaws */}
+      <Divider sx={{ my: 2 }} />
+      <Typography variant="h6" gutterBottom>
+        Reference
+      </Typography>
+      {categories.map((cat) => {
+        const catEdges = EdgesFlawsData.edges.filter((e) => e.category === cat);
+        const catFlaws = EdgesFlawsData.flaws.filter((f) => f.category === cat);
+        if (!catEdges.length && !catFlaws.length) return null;
+        return (
+          <Box key={cat} sx={{ mb: 1.5 }}>
+            <Typography variant="subtitle2" color="primary" gutterBottom>
+              {cat}
+            </Typography>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+              {catEdges.map((e) => (
+                <Chip
+                  key={e.id}
+                  size="small"
+                  color="success"
+                  variant="outlined"
+                  label={`${e.name} (${e.costOptions ? e.costOptions.map((o) => o.value).join("/") : "+" + e.cost})`}
+                  title={e.description + (e.restrictions ? " [" + e.restrictions + "]" : "")}
+                />
+              ))}
+              {catFlaws.map((f) => (
+                <Chip
+                  key={f.id}
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  label={`${f.name} (${f.costOptions ? f.costOptions.map((o) => o.value).join("/") : f.cost})`}
+                  title={f.description + (f.restrictions ? " [" + f.restrictions + "]" : "")}
+                />
+              ))}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/IdentityPanel.js
+++ b/src/components/IdentityPanel.js
@@ -67,13 +67,19 @@ export default function IdentityPanel(props) {
                 <li>Some issues with Knowledge and Langauge skills being edited or removed</li>
                 <li>Still need to add "improvements" and tracking Nuyen post finalization.</li>
                 <li>All nesting of improvements (Weapon / Deck / Vehicle accessories and building). These will be handled in a completely different way, but I promise it will feel awesome to do!</li>
-                <li>Otaku Sprites section is still pending implementation</li>
                 <li>Decker programming calculator (design and program your own utilities) not yet implemented</li>
             </ul>
         </div>
         <hr/>
         <h5>Resolved Issues</h5>
         <ul>
+            <li>Edges &amp; Flaws system (Shadowrun Companion) — full implementation with all ~65 Edges and Flaws, picker UI, variable-cost tiers, and balance enforcement (net-zero for Priority, ±6 BP cap for Point Buy)</li>
+            <li>Otaku Submersion grades, Echoes, and Tribe tracker added (mirroring the Initiation system). Costs follow Matrix book formula: (grade × 2) + 10 Karma</li>
+            <li>Otaku Sprites section fully implemented with SearchableSelect dropdowns and Living Persona formula display</li>
+            <li>SR3 Giants Body stat corrected to 5 (was 4); racial limits added to Attributes panel (were entirely missing)</li>
+            <li>SR3 and SR2 Ogre notes corrected — Ogres do NOT have Low-Light Vision unlike other Orks</li>
+            <li>Cloud Save button redesigned to match the Save/Load row style and opens a modal instead of an accordion</li>
+            <li>All magical tradition descriptions, conjure types, and dice bonuses filled in from the Magic in the Shadows sourcebook</li>
             <li>Full SR3 Cannon Companion weapons audit — corrected concealability and ammo capacity on modular weapon systems (HK G38, Steyr AUG-CSL), Ares Thunderer concealability, and weapon type classifications for Hammerli 610S and Morrissey Elite</li>
             <li>SR3 Decking Panel — fixed all direct state mutations (addProgram, removeProgram, persona changes, program rating/toggle). Added SearchableSelect dropdowns to cyberdeck and program selectors</li>
             <li>SR3 Otaku Panel — all Living Persona formulas verified against the Matrix book (MPCP, Bod, Sensor, Masking, Evasion, Hardening, Matrix Reaction, Matrix Initiative, I/O Speed, Hacking Pool). Fixed several previously invented/incorrect formulas</li>

--- a/src/components/PointBuyPanel.js
+++ b/src/components/PointBuyPanel.js
@@ -62,13 +62,13 @@ export default function PointBuyPanelSR3(props) {
           Notes: "Low-Light Vision",
         },
         Giants:{
-          Body: 4,
+          Body: 5,
           Quickness: -1,
           Strength: 5,
           Charisma: -2,
           Willpower: 0,
           Intelligence: -2,
-          Notes: "Thermographic Vision, +1 Reach for Armed/Unarmed Combat",
+          Notes: "Thermographic Vision, +1 Reach for Armed/Unarmed Combat. No dermal armor.",
         },
         Gnome:{
           Body: 1,
@@ -104,7 +104,7 @@ export default function PointBuyPanelSR3(props) {
           Charisma: 0,
           Willpower: 0,
           Intelligence: -1,
-          Notes: "",
+          Notes: "No Low-Light Vision (unlike other Orks).",
         },
         Minotaurs:{
           Body: 4,
@@ -275,13 +275,13 @@ export default function PointBuyPanelSR3(props) {
           Notes: "Low-Light Vision",
         },
         Ogre:{
-         Body: 3,
+          Body: 3,
           Quickness: 0,
           Strength: 2,
           Charisma: 0,
           Willpower: 0,
           Intelligence: -1,
-          Notes: "Low-light Vision",
+          Notes: "No Low-Light Vision (unlike other Orks).",
         },
         Minotaurs:{
           Body: 4,

--- a/src/data/SR3/EdgesAndFlaws.json
+++ b/src/data/SR3/EdgesAndFlaws.json
@@ -1,0 +1,957 @@
+{
+  "edges": [
+    {
+      "id": "bonus-attribute-point",
+      "name": "Bonus Attribute Point",
+      "category": "Attributes",
+      "cost": 2,
+      "description": "Gain 1 bonus Attribute Point to any Mental or Physical attribute. Only one attribute per character may be raised this way, and only one bonus point per attribute.",
+      "restrictions": null
+    },
+    {
+      "id": "exceptional-attribute",
+      "name": "Exceptional Attribute",
+      "category": "Attributes",
+      "cost": 2,
+      "description": "Increase the Racial Modified Limit for one attribute by 1 (also raises the maximum by 1).",
+      "restrictions": null,
+      "userInput": "attribute"
+    },
+    {
+      "id": "aptitude",
+      "name": "Aptitude",
+      "category": "Skills",
+      "cost": 4,
+      "description": "−1 TN to all tests using one chosen skill.",
+      "restrictions": null,
+      "userInput": "skill"
+    },
+    {
+      "id": "home-ground",
+      "name": "Home Ground",
+      "category": "Skills",
+      "cost": 2,
+      "description": "−1 TN for Active Skills on home turf; −2 TN for Knowledge Skills there.",
+      "restrictions": null,
+      "userInput": "location"
+    },
+    {
+      "id": "adrenaline-surge",
+      "name": "Adrenaline Surge",
+      "category": "Physical",
+      "cost": 2,
+      "description": "Apply the Rule of Six to Initiative rolls, but suffer +1 TN on all Combat and Perception tests. Not available to characters with cyberware, bioware, or magic that already enhances initiative.",
+      "restrictions": "Not for cyber/bio/magic-enhanced characters"
+    },
+    {
+      "id": "double-jointed",
+      "name": "Double Jointed",
+      "category": "Physical",
+      "cost": 1,
+      "description": "−1 TN for Athletics (Escape Artist) tests.",
+      "restrictions": null
+    },
+    {
+      "id": "high-pain-tolerance",
+      "name": "High Pain Tolerance",
+      "category": "Physical",
+      "cost": 2,
+      "costNote": "2 pts per box",
+      "description": "Resist 1 box of damage per 2 points spent. Each purchase adds one box of damage resistance.",
+      "restrictions": null,
+      "repeatable": true
+    },
+    {
+      "id": "lightning-reflexes",
+      "name": "Lightning Reflexes",
+      "category": "Physical",
+      "costOptions": [
+        { "value": 2, "label": "+1 Reaction (surprise only)" },
+        { "value": 4, "label": "+2 Reaction (surprise only)" },
+        { "value": 6, "label": "+3 Reaction (surprise only, max)" }
+      ],
+      "description": "+1 Reaction per 2 points, for surprise situations only (max +3). Not compatible with Combat Sense.",
+      "restrictions": "Not compatible with Combat Sense"
+    },
+    {
+      "id": "natural-immunity",
+      "name": "Natural Immunity",
+      "category": "Physical",
+      "costOptions": [
+        { "value": 1, "label": "Natural toxin" },
+        { "value": 3, "label": "Man-made toxin" }
+      ],
+      "description": "Complete immunity to one specific natural (1 pt) or man-made (3 pts) toxin.",
+      "restrictions": null,
+      "userInput": "toxin"
+    },
+    {
+      "id": "night-vision",
+      "name": "Night Vision",
+      "category": "Physical",
+      "costOptions": [
+        { "value": 2, "label": "Standard (2 pts)" },
+        { "value": 1, "label": "Rigger/Decker (1 pt)" }
+      ],
+      "description": "Low-light vision for humans (elves and orks already have this ability).",
+      "restrictions": "Human characters only (elves and orks already have low-light vision)"
+    },
+    {
+      "id": "quick-healer",
+      "name": "Quick Healer",
+      "category": "Physical",
+      "cost": 2,
+      "description": "−2 TN on Healing Tests (both natural healing and medical aid).",
+      "restrictions": null
+    },
+    {
+      "id": "resistance-to-pathogens",
+      "name": "Resistance to Pathogens",
+      "category": "Physical",
+      "cost": 1,
+      "description": "+1 Body die when resisting disease.",
+      "restrictions": null
+    },
+    {
+      "id": "resistance-to-toxins",
+      "name": "Resistance to Toxins",
+      "category": "Physical",
+      "cost": 1,
+      "description": "+1 Body die when resisting toxins and drugs.",
+      "restrictions": null
+    },
+    {
+      "id": "toughness",
+      "name": "Toughness",
+      "category": "Physical",
+      "cost": 3,
+      "description": "+1 Body die for Damage Resistance Tests.",
+      "restrictions": null
+    },
+    {
+      "id": "water-sprite",
+      "name": "Water Sprite",
+      "category": "Physical",
+      "cost": 1,
+      "costNote": "1 pt per ability",
+      "description": "Each point improves one aquatic ability: extended breath-holding, improved swimming speed, or reduced penalties for underwater actions.",
+      "restrictions": null,
+      "repeatable": true
+    },
+    {
+      "id": "will-to-live",
+      "name": "Will to Live",
+      "category": "Physical",
+      "costOptions": [
+        { "value": 1, "label": "+1 Overflow Box" },
+        { "value": 2, "label": "+2 Overflow Boxes" },
+        { "value": 3, "label": "+3 Overflow Boxes" }
+      ],
+      "description": "+1 Damage Overflow Box per point spent (delays death).",
+      "restrictions": null
+    },
+    {
+      "id": "bravery",
+      "name": "Bravery",
+      "category": "Mental",
+      "cost": 1,
+      "description": "−1 TN to resist fear and intimidation.",
+      "restrictions": null
+    },
+    {
+      "id": "college-education",
+      "name": "College Education",
+      "category": "Mental",
+      "cost": 1,
+      "description": "Reduced defaulting penalties when using Academic Knowledge Skills without specialization.",
+      "restrictions": null
+    },
+    {
+      "id": "common-sense",
+      "name": "Common Sense",
+      "category": "Mental",
+      "cost": 2,
+      "description": "The GM must warn the player before the character takes an action that seems foolish or dangerous.",
+      "restrictions": null
+    },
+    {
+      "id": "perceptive",
+      "name": "Perceptive",
+      "category": "Mental",
+      "cost": 3,
+      "description": "−1 TN on all Perception Tests, including Astral Perception.",
+      "restrictions": null
+    },
+    {
+      "id": "perfect-time",
+      "name": "Perfect Time",
+      "category": "Mental",
+      "cost": 1,
+      "description": "The character always knows the exact time without needing a timepiece.",
+      "restrictions": null
+    },
+    {
+      "id": "photographic-memory",
+      "name": "Photographic Memory",
+      "category": "Mental",
+      "cost": 3,
+      "description": "Perfect recall of anything the character has seen or heard.",
+      "restrictions": null
+    },
+    {
+      "id": "sense-of-direction",
+      "name": "Sense of Direction",
+      "category": "Mental",
+      "cost": 1,
+      "description": "The character never gets lost and always knows true north.",
+      "restrictions": null
+    },
+    {
+      "id": "spike-resistance",
+      "name": "Spike Resistance",
+      "category": "Mental",
+      "costOptions": [
+        { "value": 2, "label": "+1 effective WIL vs simsense damage" },
+        { "value": 4, "label": "+2 effective WIL vs simsense damage" }
+      ],
+      "description": "+1 effective Willpower per 2 points when resisting simsense damage.",
+      "restrictions": "Riggers and Deckers only"
+    },
+    {
+      "id": "technical-school-education",
+      "name": "Technical School Education",
+      "category": "Mental",
+      "cost": 1,
+      "description": "Reduced defaulting penalties when using Background (Technical) Knowledge Skills without specialization.",
+      "restrictions": null
+    },
+    {
+      "id": "animal-empathy",
+      "name": "Animal Empathy",
+      "category": "Social",
+      "cost": 2,
+      "description": "−1 TN on tests to influence or control animals.",
+      "restrictions": null
+    },
+    {
+      "id": "blandness",
+      "name": "Blandness",
+      "category": "Social",
+      "cost": 2,
+      "description": "+1 TN for anyone attempting to track or locate the character.",
+      "restrictions": null
+    },
+    {
+      "id": "connected",
+      "name": "Connected",
+      "category": "Social",
+      "costOptions": [
+        { "value": 3, "label": "One contact (limited contraband)" },
+        { "value": 5, "label": "One contact (all contraband)" }
+      ],
+      "description": "One contact always buys and sells contraband at the best possible price for the character.",
+      "restrictions": null,
+      "userInput": "contact type"
+    },
+    {
+      "id": "extra-contact",
+      "name": "Extra Contact",
+      "category": "Social",
+      "cost": 1,
+      "description": "Gain 1 additional Level 1 contact.",
+      "restrictions": null,
+      "repeatable": true,
+      "userInput": "contact"
+    },
+    {
+      "id": "friendly-face",
+      "name": "Friendly Face",
+      "category": "Social",
+      "cost": 1,
+      "description": "−1 TN on Social Skill Tests when in unfamiliar environments or meeting strangers.",
+      "restrictions": null
+    },
+    {
+      "id": "friends-abroad",
+      "name": "Friends Abroad",
+      "category": "Social",
+      "cost": 3,
+      "description": "Gain one extra foreign contact and the ability to establish new contacts in foreign nations more easily.",
+      "restrictions": null,
+      "userInput": "country/region"
+    },
+    {
+      "id": "friends-in-high-places",
+      "name": "Friends in High Places",
+      "category": "Social",
+      "cost": 2,
+      "description": "Gain influential Level 2 contacts in high social circles.",
+      "restrictions": null,
+      "userInput": "organization/circle"
+    },
+    {
+      "id": "good-looking-knows-it",
+      "name": "Good Looking and Knows It",
+      "category": "Social",
+      "cost": 1,
+      "description": "−2 TN on Social and Etiquette Tests with the opposite sex; +1 TN with same sex (example edge).",
+      "restrictions": null
+    },
+    {
+      "id": "good-reputation",
+      "name": "Good Reputation",
+      "category": "Social",
+      "costOptions": [
+        { "value": 1, "label": "−1 TN Social Skills" },
+        { "value": 2, "label": "−2 TN Social Skills" }
+      ],
+      "description": "−1 TN on Social Skills per point spent.",
+      "restrictions": null
+    },
+    {
+      "id": "human-looking",
+      "name": "Human-Looking",
+      "category": "Social",
+      "cost": 1,
+      "description": "An elf or dwarf (or ork if using metavariant rules) who can pass as human; negates racial social penalties.",
+      "restrictions": "Elves, Dwarves, or qualifying Orks only. Metavariants cannot take this Edge."
+    },
+    {
+      "id": "astral-chameleon",
+      "name": "Astral Chameleon",
+      "category": "Magical",
+      "cost": 2,
+      "description": "Astral signatures fade as if Force were 1 lower; +2 TN for others to assense the character's signatures.",
+      "restrictions": "Awakened characters only"
+    },
+    {
+      "id": "focused-concentration",
+      "name": "Focused Concentration",
+      "category": "Magical",
+      "cost": 2,
+      "description": "Only +1 TN when sustaining spells (instead of +2); can sustain Sorcery Skill +1 spells simultaneously.",
+      "restrictions": "Awakened characters only"
+    },
+    {
+      "id": "magic-resistance",
+      "name": "Magic Resistance",
+      "category": "Magical",
+      "costOptions": [
+        { "value": 1, "label": "+1 die Spell Resistance" },
+        { "value": 2, "label": "+2 dice Spell Resistance" },
+        { "value": 3, "label": "+3 dice Spell Resistance" },
+        { "value": 4, "label": "+4 dice Spell Resistance" }
+      ],
+      "description": "+1 die for Spell Resistance Tests per point. Works against all spells including beneficial ones. Cannot be lowered.",
+      "restrictions": "Non-Awakened characters only"
+    },
+    {
+      "id": "poor-link",
+      "name": "Poor Link",
+      "category": "Magical",
+      "cost": 2,
+      "description": "Ritual sorcery directed against the character receives +2 TN for the Link Test.",
+      "restrictions": null
+    },
+    {
+      "id": "spirit-affinity",
+      "name": "Spirit Affinity",
+      "category": "Magical",
+      "cost": 2,
+      "description": "One type of nature spirit is drawn to and favorably disposed toward the character, offering occasional favors and less likely to attack.",
+      "restrictions": null,
+      "userInput": "spirit type"
+    },
+    {
+      "id": "codeslinger",
+      "name": "Codeslinger",
+      "category": "Matrix",
+      "cost": 2,
+      "description": "Gain 1 extra die for one chosen type of system operation. May only be taken once.",
+      "restrictions": "Characters capable of decking only. Cannot be combined with Cracker.",
+      "userInput": "system operation"
+    },
+    {
+      "id": "cracker",
+      "name": "Cracker",
+      "category": "Matrix",
+      "cost": 4,
+      "description": "Gain 1 extra die for one chosen type of System Test (Access, Control, etc.). May only be taken once.",
+      "restrictions": "Characters capable of decking only. Not available to Otaku. Cannot be combined with Codeslinger.",
+      "userInput": "system test type"
+    },
+    {
+      "id": "natural-hardening",
+      "name": "Natural Hardening",
+      "category": "Matrix",
+      "cost": 4,
+      "description": "Gain 1 point of natural Hardening (stacks with cyberdeck Hardening).",
+      "restrictions": null
+    },
+    {
+      "id": "daredevil",
+      "name": "Daredevil",
+      "category": "Miscellaneous",
+      "cost": 3,
+      "description": "Once per game session, gain 1 extra Karma Pool point usable only in a heroically risky situation. Cannot be burned.",
+      "restrictions": null
+    },
+    {
+      "id": "pirate-family",
+      "name": "Pirate Family",
+      "category": "Miscellaneous",
+      "cost": 3,
+      "description": "Extended pirate family in multiple ports acts as Friends of Friends, providing contacts and assistance in unfamiliar cities worldwide.",
+      "restrictions": "Characters from pirate families only"
+    },
+    {
+      "id": "vehicle-empathy",
+      "name": "Vehicle Empathy",
+      "category": "Miscellaneous",
+      "cost": 2,
+      "description": "Reduce Handling of any vehicle by 1 when in physical contact with it (via manual controls or jacked in).",
+      "restrictions": null
+    }
+  ],
+  "flaws": [
+    {
+      "id": "incompetence",
+      "name": "Incompetence",
+      "category": "Skills",
+      "cost": -2,
+      "description": "+1 TN to all tests with one chosen skill.",
+      "restrictions": null,
+      "userInput": "skill"
+    },
+    {
+      "id": "computer-illiterate",
+      "name": "Computer Illiterate",
+      "category": "Skills",
+      "cost": -3,
+      "description": "+1 TN on all computer-related tests; may require Success Tests for tasks a normal person could do automatically.",
+      "restrictions": null
+    },
+    {
+      "id": "allergy",
+      "name": "Allergy",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -2, "label": "Uncommon + Mild" },
+        { "value": -3, "label": "Uncommon + Moderate, or Common + Mild" },
+        { "value": -4, "label": "Uncommon + Severe, or Common + Moderate" },
+        { "value": -5, "label": "Common + Severe" }
+      ],
+      "description": "Allergic reaction to a specific substance. Severity and rarity determine the point value.",
+      "restrictions": null,
+      "userInput": "allergen"
+    },
+    {
+      "id": "bio-rejection",
+      "name": "Bio-Rejection",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -5, "label": "Standard (−5)" },
+        { "value": -2, "label": "Magically active character (−2)" }
+      ],
+      "description": "Cannot use cyberware implants of any kind.",
+      "restrictions": null
+    },
+    {
+      "id": "blind",
+      "name": "Blind",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -6, "label": "Standard (−6)" },
+        { "value": -2, "label": "Magically active character (−2)" }
+      ],
+      "description": "+6 TN on all visually dependent tests. Cannot be corrected by cybereyes.",
+      "restrictions": null
+    },
+    {
+      "id": "borrowed-time",
+      "name": "Borrowed Time",
+      "category": "Physical",
+      "cost": -6,
+      "description": "The GM secretly rolls 3D6 to determine how many months the character has to live. The character does not know their fate.",
+      "restrictions": null
+    },
+    {
+      "id": "color-blind",
+      "name": "Color Blind",
+      "category": "Physical",
+      "cost": -1,
+      "description": "+4 TN for any test that requires distinguishing colors.",
+      "restrictions": null
+    },
+    {
+      "id": "deaf",
+      "name": "Deaf",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -3, "label": "Standard (−3)" },
+        { "value": -1, "label": "Rigger or Decker (−1)" }
+      ],
+      "description": "Cannot hear; +4 TN on any test where hearing is a factor.",
+      "restrictions": null
+    },
+    {
+      "id": "infirm",
+      "name": "Infirm",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -1, "label": "−1 Physical Attribute Maximum" },
+        { "value": -2, "label": "−2 Physical Attribute Maximums" },
+        { "value": -3, "label": "−3 Physical Attribute Maximums" },
+        { "value": -4, "label": "−4 Physical Attribute Maximums" },
+        { "value": -5, "label": "−5 Physical Attribute Maximums" }
+      ],
+      "description": "−1 Physical Attribute Maximum per point (affects one attribute per point, chosen at character creation).",
+      "restrictions": null,
+      "userInput": "affected attributes"
+    },
+    {
+      "id": "low-pain-tolerance",
+      "name": "Low Pain Tolerance",
+      "category": "Physical",
+      "cost": -4,
+      "description": "Treat wound level as one higher for determining target number modifiers.",
+      "restrictions": null
+    },
+    {
+      "id": "night-blindness",
+      "name": "Night Blindness",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -2, "label": "Standard (−2)" },
+        { "value": -1, "label": "Rigger or Decker (−1)" }
+      ],
+      "description": "+2 TN in darkness conditions, cumulative with standard lighting modifiers.",
+      "restrictions": null
+    },
+    {
+      "id": "paraplegic",
+      "name": "Paraplegic",
+      "category": "Physical",
+      "cost": -3,
+      "description": "Combat Pool is halved. No effect while in the Matrix or astral plane.",
+      "restrictions": null
+    },
+    {
+      "id": "quadriplegic",
+      "name": "Quadriplegic",
+      "category": "Physical",
+      "cost": -6,
+      "description": "Paralyzed from the neck down. Requires Hospitalized lifestyle to survive.",
+      "restrictions": null
+    },
+    {
+      "id": "sensitive-system",
+      "name": "Sensitive System",
+      "category": "Physical",
+      "costOptions": [
+        { "value": -3, "label": "Standard (−3)" },
+        { "value": -2, "label": "Magically active character (−2)" }
+      ],
+      "description": "All Essence losses from cyberware are doubled.",
+      "restrictions": null
+    },
+    {
+      "id": "weak-immune-system",
+      "name": "Weak Immune System",
+      "category": "Physical",
+      "cost": -1,
+      "description": "−1 Body die when resisting disease.",
+      "restrictions": null
+    },
+    {
+      "id": "amnesia",
+      "name": "Amnesia",
+      "category": "Mental",
+      "costOptions": [
+        { "value": -2, "label": "Mild: partial memory loss" },
+        { "value": -3, "label": "Moderate: significant memory loss" },
+        { "value": -4, "label": "Severe: most memory lost" },
+        { "value": -5, "label": "Total: complete memory loss" }
+      ],
+      "description": "Lost memories; severity determines how many skills and contacts are retained.",
+      "restrictions": null
+    },
+    {
+      "id": "combat-monster",
+      "name": "Combat Monster",
+      "category": "Mental",
+      "cost": -1,
+      "description": "Cannot break off from a fight for 3 turns; requires a Willpower (6) test to disengage sooner.",
+      "restrictions": null
+    },
+    {
+      "id": "combat-paralysis",
+      "name": "Combat Paralysis",
+      "category": "Mental",
+      "cost": -4,
+      "description": "Minimum Initiative roll on the first turn of combat; +2 TN on Surprise Tests.",
+      "restrictions": null
+    },
+    {
+      "id": "compulsive",
+      "name": "Compulsive",
+      "category": "Mental",
+      "costOptions": [
+        { "value": -1, "label": "Minor compulsion (low danger)" },
+        { "value": -2, "label": "Moderate compulsion" },
+        { "value": -3, "label": "Major compulsion (high danger)" }
+      ],
+      "description": "Character has a compulsive behavior; value based on how dangerous or disruptive it is.",
+      "restrictions": null,
+      "userInput": "compulsion"
+    },
+    {
+      "id": "flashbacks",
+      "name": "Flashbacks",
+      "category": "Mental",
+      "cost": -4,
+      "description": "Willpower (6) test when encountering a trigger or when rendered incapacitated; failure causes 1D6 minute incapacitation.",
+      "restrictions": null,
+      "userInput": "trigger"
+    },
+    {
+      "id": "illiterate",
+      "name": "Illiterate",
+      "category": "Mental",
+      "cost": -3,
+      "description": "Knowledge Skills limited to INT×3; no Academic Skills; +4 TN on computer tests.",
+      "restrictions": null
+    },
+    {
+      "id": "impulsive",
+      "name": "Impulsive",
+      "category": "Mental",
+      "cost": -2,
+      "description": "Must pass Willpower (6) test to avoid jumping into dangerous situations.",
+      "restrictions": null
+    },
+    {
+      "id": "oblivious",
+      "name": "Oblivious",
+      "category": "Mental",
+      "cost": -2,
+      "description": "+1 TN on all Perception Tests.",
+      "restrictions": null
+    },
+    {
+      "id": "pacifist",
+      "name": "Pacifist",
+      "category": "Mental",
+      "cost": -2,
+      "description": "Cannot kill except in clear self-defense.",
+      "restrictions": null
+    },
+    {
+      "id": "phobia",
+      "name": "Phobia",
+      "category": "Mental",
+      "costOptions": [
+        { "value": -2, "label": "Uncommon + Mild" },
+        { "value": -3, "label": "Uncommon + Moderate, or Common + Mild" },
+        { "value": -4, "label": "Uncommon + Severe, or Common + Moderate" },
+        { "value": -5, "label": "Common + Severe" }
+      ],
+      "description": "Irrational fear of something; rarity and severity determine value (same structure as Allergy).",
+      "restrictions": null,
+      "userInput": "phobia subject"
+    },
+    {
+      "id": "sea-legs",
+      "name": "Sea Legs",
+      "category": "Mental",
+      "cost": -2,
+      "description": "After 24 hours on land, character feels a compulsive need to return to the sea.",
+      "restrictions": null
+    },
+    {
+      "id": "sea-madness",
+      "name": "Sea Madness",
+      "category": "Mental",
+      "cost": -4,
+      "description": "After 24 hours at sea with no land in sight, character goes mad.",
+      "restrictions": null
+    },
+    {
+      "id": "sensitive-neural-structure",
+      "name": "Sensitive Neural Structure",
+      "category": "Mental",
+      "costOptions": [
+        { "value": -2, "label": "−1 effective WIL vs neural damage" },
+        { "value": -4, "label": "−2 effective WIL vs neural damage" }
+      ],
+      "description": "Reduced effective Willpower when resisting neural damage.",
+      "restrictions": null
+    },
+    {
+      "id": "simsense-vertigo",
+      "name": "Simsense Vertigo",
+      "category": "Mental",
+      "costOptions": [
+        { "value": -2, "label": "Standard (−2)" },
+        { "value": -4, "label": "Rigger or Decker (−4)" }
+      ],
+      "description": "+1 TN and −1 Initiative when using simsense devices.",
+      "restrictions": null
+    },
+    {
+      "id": "total-pacifist",
+      "name": "Total Pacifist",
+      "category": "Mental",
+      "cost": -5,
+      "description": "Cannot kill or cause harm to any creature more intelligent than an insect.",
+      "restrictions": null
+    },
+    {
+      "id": "uneducated",
+      "name": "Uneducated",
+      "category": "Mental",
+      "cost": -2,
+      "description": "Knowledge Skills limited to INT×3; no Academic or Background Knowledge Skills; only one language.",
+      "restrictions": null
+    },
+    {
+      "id": "vindictive",
+      "name": "Vindictive",
+      "category": "Mental",
+      "cost": -2,
+      "description": "Goes out of the way to avenge any slight, no matter how minor.",
+      "restrictions": null
+    },
+    {
+      "id": "bad-reputation",
+      "name": "Bad Reputation",
+      "category": "Social",
+      "costOptions": [
+        { "value": -1, "label": "+1 TN Social Skills" },
+        { "value": -2, "label": "+2 TN Social Skills" },
+        { "value": -3, "label": "+3 TN Social Skills" },
+        { "value": -4, "label": "+4 TN Social Skills" }
+      ],
+      "description": "+1 TN on Social Skills per point; character is widely known for bad acts.",
+      "restrictions": null
+    },
+    {
+      "id": "braggart",
+      "name": "Braggart",
+      "category": "Social",
+      "cost": -1,
+      "description": "Must succeed at an Intelligence (6) test to avoid boasting about accomplishments.",
+      "restrictions": null
+    },
+    {
+      "id": "dark-secret",
+      "name": "Dark Secret",
+      "category": "Social",
+      "cost": -2,
+      "description": "Character has a terrible secret that must be kept hidden at all costs.",
+      "restrictions": null,
+      "userInput": "secret"
+    },
+    {
+      "id": "day-job",
+      "name": "Day Job",
+      "category": "Social",
+      "costOptions": [
+        { "value": -1, "label": "10 hours/week" },
+        { "value": -2, "label": "20 hours/week" },
+        { "value": -3, "label": "40 hours/week" }
+      ],
+      "description": "Character has a legitimate job requiring regular hours, limiting shadowrunning time.",
+      "restrictions": null,
+      "userInput": "job"
+    },
+    {
+      "id": "dependent",
+      "name": "Dependent",
+      "category": "Social",
+      "costOptions": [
+        { "value": -1, "label": "Minor dependent (child, elderly)" },
+        { "value": -2, "label": "Moderate dependent" },
+        { "value": -3, "label": "Major dependent (disabled)" }
+      ],
+      "description": "Character has a loved one who requires ongoing support, attention, or protection.",
+      "restrictions": null,
+      "userInput": "dependent"
+    },
+    {
+      "id": "distinctive-style",
+      "name": "Distinctive Style",
+      "category": "Social",
+      "cost": -1,
+      "description": "−1 TN for anyone attempting to track or identify the character (opposite of Blandness).",
+      "restrictions": null
+    },
+    {
+      "id": "elf-poser",
+      "name": "Elf Poser",
+      "category": "Social",
+      "cost": -1,
+      "description": "Human who poses as an elf; if an actual elf discovers the secret, the character is treated with contempt and Hostility.",
+      "restrictions": "Human characters only"
+    },
+    {
+      "id": "extra-enemy",
+      "name": "Extra Enemy",
+      "category": "Social",
+      "cost": -1,
+      "description": "Gain 1 additional Enemy contact.",
+      "restrictions": null,
+      "repeatable": true,
+      "userInput": "enemy"
+    },
+    {
+      "id": "hung-out-to-dry",
+      "name": "Hung Out to Dry",
+      "category": "Social",
+      "cost": -4,
+      "description": "All contacts have dried up — no one will deal with or help the character.",
+      "restrictions": null
+    },
+    {
+      "id": "liar",
+      "name": "Liar",
+      "category": "Social",
+      "cost": -2,
+      "description": "Each address to an NPC, GM rolls 1D6; on 1, the NPC thinks the character is lying. The threshold gets worse with each encounter until contact is permanently lost.",
+      "restrictions": null
+    },
+    {
+      "id": "ugly-and-doesnt-care",
+      "name": "Ugly and Doesn't Care",
+      "category": "Social",
+      "cost": -1,
+      "description": "+2 TN Social/Etiquette with opposite sex; +1 TN with same sex. New acquaintances have Suspicious attitude (example flaw).",
+      "restrictions": null
+    },
+    {
+      "id": "uncouth",
+      "name": "Uncouth",
+      "category": "Social",
+      "cost": -2,
+      "description": "+2 TN on all Social Skill Tests, including Negotiation and Etiquette.",
+      "restrictions": null
+    },
+    {
+      "id": "astral-impressions",
+      "name": "Astral Impressions",
+      "category": "Magical",
+      "cost": -2,
+      "description": "Astral signatures last as if Force were 1 higher; −2 TN for others to assense the character's signatures.",
+      "restrictions": "Awakened characters only"
+    },
+    {
+      "id": "spirit-bane",
+      "name": "Spirit Bane",
+      "category": "Magical",
+      "cost": -2,
+      "description": "One type of nature spirit actively dislikes the character, harasses them in their domain, and will target the character first if ordered to attack.",
+      "restrictions": null,
+      "userInput": "spirit type"
+    },
+    {
+      "id": "codeblock",
+      "name": "Codeblock",
+      "category": "Matrix",
+      "cost": -1,
+      "description": "Lose 1 die whenever performing one specific type of system operation.",
+      "restrictions": "Characters capable of decking only",
+      "userInput": "system operation"
+    },
+    {
+      "id": "choker",
+      "name": "Choker",
+      "category": "Matrix",
+      "cost": -2,
+      "description": "Lose 1 die whenever performing one specific type of System Test.",
+      "restrictions": "Characters capable of decking only",
+      "userInput": "system test type"
+    },
+    {
+      "id": "jack-itch",
+      "name": "Jack Itch",
+      "category": "Matrix",
+      "cost": -1,
+      "description": "Psychosomatic itch when jacked in; after WIL minutes, adds +1 TN per WIL minutes jacked in. At +8 TN character jacks out involuntarily.",
+      "restrictions": null
+    },
+    {
+      "id": "scorched",
+      "name": "Scorched",
+      "category": "Matrix",
+      "cost": -1,
+      "description": "Near-permanent psychotropic conditioning from Black IC; character does not get Willpower Tests to resist the conditioning's effects.",
+      "restrictions": null
+    },
+    {
+      "id": "bad-karma",
+      "name": "Bad Karma",
+      "category": "Miscellaneous",
+      "cost": -5,
+      "description": "Must earn double the Karma to increase Karma Pool.",
+      "restrictions": null
+    },
+    {
+      "id": "cranial-bomb",
+      "name": "Cranial Bomb",
+      "category": "Miscellaneous",
+      "cost": -6,
+      "description": "Someone has implanted a cranial bomb in the character's head; the GM decides who and why. Bomb is free.",
+      "restrictions": null
+    },
+    {
+      "id": "cursed-karma",
+      "name": "Cursed Karma",
+      "category": "Miscellaneous",
+      "cost": -6,
+      "description": "When spending a Karma Pool point, roll 1D6; on 1, the point is spent but has the opposite of the intended effect.",
+      "restrictions": null
+    },
+    {
+      "id": "gremlins",
+      "name": "Gremlins",
+      "category": "Miscellaneous",
+      "costOptions": [
+        { "value": -1, "label": "Minor: equipment operates at ±1 modifier" },
+        { "value": -2, "label": "Moderate: equipment stops working" },
+        { "value": -3, "label": "Major: equipment malfunctions, needs repair" },
+        { "value": -4, "label": "Severe: equipment breaks, needs major overhaul" }
+      ],
+      "description": "Equipment handled by character tends to malfunction; roll 2D6 on a result of 2, equipment breaks.",
+      "restrictions": "No effect on cyberware or magical equipment"
+    },
+    {
+      "id": "hunted",
+      "name": "Hunted",
+      "category": "Miscellaneous",
+      "costOptions": [
+        { "value": -2, "label": "Rank 3 Enemy (or +1 to existing)" },
+        { "value": -4, "label": "Rank 4 Enemy (or +2 to existing)" },
+        { "value": -6, "label": "Rank 5–6 Enemy (or +3 to existing)" }
+      ],
+      "description": "Enemy aggressively hunts the character; if killed, a replacement of equal or greater rank takes over.",
+      "restrictions": null,
+      "userInput": "hunter"
+    },
+    {
+      "id": "mysterious-cyberware",
+      "name": "Mysterious Cyberware",
+      "category": "Miscellaneous",
+      "cost": -3,
+      "description": "Character has an unknown piece of cyberware the GM chose; character doesn't know it exists until the GM reveals it.",
+      "restrictions": null
+    },
+    {
+      "id": "police-record",
+      "name": "Police Record",
+      "category": "Miscellaneous",
+      "cost": -6,
+      "description": "Criminal SIN; only street-level contacts allowed; Lone Star harasses on sight; corporate security has the character's file.",
+      "restrictions": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Edges & Flaws system** — full implementation of all ~65 Edges and Flaws from the Shadowrun Companion
- **Otaku Submersion, Echoes & Tribe** — grade tracker, echo picker, and tribe card mirroring the Initiation system
- **Cloud Save redesign** — button matches the Save/Load row style; opens a modal instead of an accordion
- **Companion audit stat fixes** — SR3 Giants Body corrected to 5 (was 4); Giants racial limits added to AttributesPanel (were entirely missing); SR3 and SR2 Ogre notes corrected (Ogres do NOT have low-light vision)
- **Identity panel** — known issues updated; resolved entries added for all of the above

## What changed

### Edges & Flaws (`src/data/SR3/EdgesAndFlaws.json`, `src/components/EdgesFlawsPanel.js`)
- JSON data file with every Edge and Flaw from SRComp pp.16–31, organized by category (Attributes, Skills, Physical, Mental, Social, Magical, Matrix, Miscellaneous)
- Variable-cost tiers modeled as `costOptions` arrays for tiered items (Allergy, Phobia, Gremlins, Lightning Reflexes, Hunted, Will to Live, etc.)
- Picker UI enforces max 5 Edges / 5 Flaws
- Live BP balance tracker with warning when Priority net ≠ 0 or Point Buy exceeds ±6 BP
- Variable-cost dropdown and free-text note field (skill, allergen, phobia subject, etc.) per applicable item
- Reference section at bottom showing all available Edges/Flaws as chips with hover descriptions
- New "Edges & Flaws" tab added at position 2 in Dashboard (between Priority/Point Buy and Attributes)

### Otaku Submersion (`src/components/OtakuPanel.js`, `src/components/Dashboard.js`)
- Submersion grade tracker with Karma cost display: `(grade × 2) + 10` per Matrix book
- Echo picker (incremental vs static types, Resonance Link stacks)
- Tribe card with name, resources lifestyle, and Resonance Well fields

### Cloud Save (`src/components/SignInPopup.js`)
- Replaced Accordion with Button + Modal pattern matching the existing Save/Load row

### Stat fixes (`src/components/PointBuyPanel.js`, `src/components/AttributesPanel.js`)
- SR3 Giants Body: 4 → 5
- SR3 Giants: racial limits added to AttributesPanel (Body 10/13, Quickness 4/7, Strength 9/12, Charisma 2/5, Intelligence 4/7, Willpower 6/9)
- SR3 Ogre notes: blank → "No Low-Light Vision (unlike other Orks)"
- SR2 Ogre notes: "Low-light Vision" → "No Low-Light Vision (unlike other Orks)"

## Reviewer notes
- All 8 tests pass; build clean
- Edges & Flaws data covers SR3 only (the Companion is an SR3 book); no SR2 split needed
- The BP balance rules are enforced with warnings only — the GM and player may have house rules, so hard blocking was intentionally avoided
