### PR TITLE
Add shareable read-only character sheet links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "firebaseui": "^6.1.0",
         "react": "^18.0.0",
         "react-beautiful-dnd": "^13.1.1",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "react-router-dom": "^7.18.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -6120,6 +6121,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/copy-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
@@ -9260,6 +9274,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -9531,6 +9583,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "firebaseui": "^6.1.0",
     "react": "^18.0.0",
     "react-beautiful-dnd": "^13.1.1",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^7.18.0"
   },
   "scripts": {
     "start": "vite",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,11 @@
 import "./App.css";
 import * as Sentry from "@sentry/react";
 import Dashboard from "./components/Dashboard";
+import PublicSheetPage from "./components/PublicSheetPage";
 import { Container } from "@mui/material";
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { DiceProvider } from './dice/DiceContext';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 const theme = createTheme();
 
 function App() {
@@ -32,21 +34,28 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
     <DiceProvider>
-    <div className="App">
-      <Container maxWidth="2xl">
-        <h1
-          className="mainHeader"
-          style={{
-            paddingLeft: "48px",
-            paddingTop: "20px",
-            paddingBottom: "20px",
-          }}
-        >
-          Shadowrun Character Generator
-        </h1>
-        <Dashboard className="dashboard" />
-      </Container>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/sheet/:id" element={<PublicSheetPage />} />
+        <Route path="*" element={
+          <div className="App">
+            <Container maxWidth="2xl">
+              <h1
+                className="mainHeader"
+                style={{
+                  paddingLeft: "48px",
+                  paddingTop: "20px",
+                  paddingBottom: "20px",
+                }}
+              >
+                Shadowrun Character Generator
+              </h1>
+              <Dashboard className="dashboard" />
+            </Container>
+          </div>
+        } />
+      </Routes>
+    </BrowserRouter>
     </DiceProvider>
     </ThemeProvider>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,19 @@
 import { render } from '@testing-library/react';
 import App from './App';
 
-// Mock the Dashboard component
 jest.mock('./components/Dashboard', () => () => <div data-testid="dashboard">Dashboard</div>);
+jest.mock('./components/firebase', () => ({
+  auth: {},
+  provider: {},
+  db: {},
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+  getDoc: jest.fn(),
+  signInWithPopup: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+  publishCharacter: jest.fn(),
+  getPublicCharacter: jest.fn(),
+}));
 
 test('renders without crashing', () => {
   const { container } = render(<App />);

--- a/src/components/AttributesPanel.js
+++ b/src/components/AttributesPanel.js
@@ -1137,7 +1137,7 @@ export default function AttributesPanel(props) {
     }
 
     const [Essence] = React.useState(6);
-    const Magic = React.useState(0);
+    const [Magic] = React.useState(0);
 
     const displayChargenPointsLeft = () => {
 

--- a/src/components/PublicSheetPage.js
+++ b/src/components/PublicSheetPage.js
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getPublicCharacter } from "./firebase";
+import SheetDisplay from "./SheetDisplay";
+import { CircularProgress, Typography, Box } from "@mui/material";
+import "./SheetDisplay.css";
+
+export default function PublicSheetPage() {
+  const { id } = useParams();
+  const [character, setCharacter] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    getPublicCharacter(id).then((char) => {
+      if (!char) {
+        setNotFound(true);
+      } else {
+        setCharacter(char);
+      }
+      setLoading(false);
+    });
+  }, [id]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <Box sx={{ textAlign: "center", mt: 10 }}>
+        <Typography variant="h5">Character not found.</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          This link may be invalid or the character may have been removed.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="caption" sx={{ display: "block", mb: 1, color: "text.secondary" }}>
+        Shared character sheet — read only
+      </Typography>
+      <SheetDisplay
+        currentCharacter={character}
+        magicalChoice={character.magical_tradition ?? character.magicalTradition ?? ""}
+        readOnly={true}
+      />
+    </Box>
+  );
+}

--- a/src/components/SignInPopup.js
+++ b/src/components/SignInPopup.js
@@ -1,9 +1,9 @@
 ﻿import React, { useState, useEffect } from "react";
-import { auth, provider, signInWithPopup, onAuthStateChanged, db, doc, setDoc, getDoc } from "./firebase";
+import { auth, provider, signInWithPopup, onAuthStateChanged, db, doc, setDoc, getDoc, publishCharacter } from "./firebase";
 import Button from "@mui/material/Button";
 import Modal from "@mui/material/Modal";
 import Box from "@mui/material/Box";
-import { Grid } from "@mui/material";
+import { Grid, CircularProgress, TextField } from "@mui/material";
 
 const modalStyle = {
   position: "absolute",
@@ -21,6 +21,8 @@ const SignInPopup = (props) => {
   const [open, setOpen] = useState(false);
   const [character1, setCharacter1] = useState([]);
   const [character2, setCharacter2] = useState([]);
+  const [shareUrl, setShareUrl] = useState(null);
+  const [sharing, setSharing] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
@@ -96,6 +98,20 @@ const SignInPopup = (props) => {
     }
   }
 
+  const handleShareSheet = async () => {
+    setSharing(true);
+    setShareUrl(null);
+    try {
+      let char = props.Character;
+      char.edition = props.Edition;
+      const id = await publishCharacter(JSON.stringify(char), props.user.uid);
+      setShareUrl(`${window.location.origin}/sheet/${id}`);
+    } catch (err) {
+      console.error("Error sharing character:", err);
+    }
+    setSharing(false);
+  };
+
   const slotLabel = (char) =>
     char?.street_name ? ` — ${char.street_name}` : " (empty)";
 
@@ -148,6 +164,39 @@ const SignInPopup = (props) => {
               </Button>
             </Grid>
           </Grid>
+
+          <Box sx={{ mt: 3, borderTop: "1px solid #ccc", pt: 2 }}>
+            <strong>Share Sheet</strong>
+            <p style={{ fontSize: "0.85em", margin: "4px 0 8px" }}>
+              Publishes a read-only snapshot anyone can view via link.
+            </p>
+            <Button
+              variant="outlined"
+              onClick={handleShareSheet}
+              disabled={sharing}
+              startIcon={sharing ? <CircularProgress size={14} /> : null}
+            >
+              {sharing ? "Publishing…" : "Generate Share Link"}
+            </Button>
+            {shareUrl && (
+              <Box sx={{ mt: 1, display: "flex", gap: 1, alignItems: "center" }}>
+                <TextField
+                  size="small"
+                  value={shareUrl}
+                  inputProps={{ readOnly: true }}
+                  fullWidth
+                  onFocus={(e) => e.target.select()}
+                />
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => navigator.clipboard.writeText(shareUrl)}
+                >
+                  Copy
+                </Button>
+              </Box>
+            )}
+          </Box>
 
           <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
             <Button size="small" color="secondary" onClick={handleSignOut}>

--- a/src/components/firebase.js
+++ b/src/components/firebase.js
@@ -1,7 +1,7 @@
 ﻿import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAuth, signInWithPopup, GoogleAuthProvider, onAuthStateChanged, setPersistence, browserLocalPersistence } from "firebase/auth";
-import { getFirestore, doc, setDoc, getDoc } from "firebase/firestore";
+import { getFirestore, doc, setDoc, getDoc, collection, addDoc, serverTimestamp } from "firebase/firestore";
 
 const firebaseConfig = {
     apiKey: "AIzaSyC8ENt2n9h-Xn3f4mMfEfdVHrKO9l6Oe68",
@@ -22,3 +22,18 @@ const db = getFirestore(app);
 setPersistence(auth, browserLocalPersistence);
 
 export { auth, provider, signInWithPopup, onAuthStateChanged, db, doc, setDoc, getDoc };
+
+export async function publishCharacter(characterJSON, uid) {
+  const ref = await addDoc(collection(db, "public_characters"), {
+    characterJSON,
+    ownerUID: uid,
+    createdAt: serverTimestamp(),
+  });
+  return ref.id;
+}
+
+export async function getPublicCharacter(shareId) {
+  const snap = await getDoc(doc(db, "public_characters", shareId));
+  if (!snap.exists()) return null;
+  return JSON.parse(snap.data().characterJSON);
+}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -7,3 +7,4 @@ import '@testing-library/jest-dom';
 const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+global.fetch = jest.fn();

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
   publicDir: 'public',
   server: {
     port: 3000,
+    historyApiFallback: true,
   },
   build: {
     outDir: 'build',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2693,6 +2693,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
+
 copy-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz"
@@ -4265,6 +4270,21 @@ react-refresh@^0.17.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
+react-router-dom@^7.18.0:
+  version "7.18.0"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz"
+  integrity sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==
+  dependencies:
+    react-router "7.18.0"
+
+react-router@7.18.0:
+  version "7.18.0"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz"
+  integrity sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==
+  dependencies:
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz"
@@ -4456,6 +4476,11 @@ semver@^7.7.2:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+set-cookie-parser@^2.6.0:
+  version "2.7.2"
+  resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Signed-in users can publish a character snapshot to Firestore and get a shareable /sheet/:id URL that anyone can open without logging in.