### PR TITLE
Add SR3 Programming Calculator tab

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,6 +22,7 @@ import VehiclesPanel from "./VehiclesPanel";
 import VehicleDesigner from "./VehicleDesigner";
 import WeaponDesigner from "./WeaponDesigner";
 import CyberdeckDesigner from "./CyberdeckDesigner";
+import ProgrammingCalculator from "./ProgrammingCalculator";
 import ContactsPanel from "./ContactsPanel";
 import SheetDisplay from "./SheetDisplay";
 import KarmaDisplay from "./KarmaDisplay";
@@ -154,6 +155,7 @@ export default function BasicTabs() {
       VehicleDesigner: false,
       WeaponDesigner: false,
       CyberdeckDesigner: false,
+      ProgrammingCalculator: false,
     },
     inventory: [],
     weapons: [],
@@ -737,6 +739,7 @@ export default function BasicTabs() {
             {Character.characterTabs?.VehicleDesigner && <Tab label="Vehicle Designer" value={13} {...a11yProps(13)} />}
             {Character.characterTabs?.WeaponDesigner && <Tab label="Weapon Designer" value={14} {...a11yProps(14)} />}
             {Character.characterTabs?.CyberdeckDesigner && <Tab label="Cyberdeck Designer" value={15} {...a11yProps(15)} />}
+            {Character.characterTabs?.ProgrammingCalculator && <Tab label="Programming" value={16} {...a11yProps(16)} />}
           </Tabs>
 
         </Box>
@@ -1090,6 +1093,9 @@ export default function BasicTabs() {
               setCharacter({ ...Character, customDecks });
             }}
           />
+        </CustomTabPanel>
+        <CustomTabPanel value={value} index={16}>
+          <ProgrammingCalculator />
         </CustomTabPanel>
       </Box>
     </div>

--- a/src/components/IdentityPanel.js
+++ b/src/components/IdentityPanel.js
@@ -95,6 +95,13 @@ export default function IdentityPanel(props) {
                         labelPlacement="end"
                         disabled={false}
                     />
+                    <FormControlLabel
+                        value="top"
+                        control={<Checkbox {...label} name="ProgrammingCalculator" color="default" onChange={handleChangeCharacterTabs} checked={Tabs.ProgrammingCalculator ?? false} />}
+                        label="Programming Calculator Tab"
+                        labelPlacement="end"
+                        disabled={false}
+                    />
                 </FormGroup>
             </FormControl>
 

--- a/src/components/ProgrammingCalculator.js
+++ b/src/components/ProgrammingCalculator.js
@@ -1,0 +1,561 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box, Typography, TextField, Paper, Chip, Alert,
+  FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel,
+  Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  Accordion, AccordionSummary, AccordionDetails, Divider, Tooltip, Grid,
+  ToggleButton, ToggleButtonGroup
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  programSize, maxProgramRating, suiteSizeMp, suiteCompDice,
+  baseTimeDays, baseTimeHours, taskPeriodDays, taskPeriodHours,
+  ProgrammingModifiers, planTimeHours, planSizeMp, planTN,
+  ProgrammingLanguages, bugTestTN, upgradeBaseTimeDays
+} from '../data/SR3/ProgrammingRules';
+
+function fmt(n, unit = '') {
+  if (n == null) return '—';
+  return `${Math.round(n).toLocaleString()}${unit ? ' ' + unit : ''}`;
+}
+
+function fmtDays(days) {
+  if (days == null) return '—';
+  const h = days * 8;
+  if (days === 1) return '1 day (8 hrs)';
+  return `${fmt(days)} days (${fmt(h)} hrs)`;
+}
+
+function InfoTip({ text }) {
+  return (
+    <Tooltip title={text} placement="right">
+      <InfoOutlinedIcon fontSize="small" sx={{ color: 'text.secondary', cursor: 'help', ml: 0.5, verticalAlign: 'middle' }} />
+    </Tooltip>
+  );
+}
+
+function StatRow({ label, value, highlight, caption }) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+      <Typography variant="body2" color="text.secondary">{label}</Typography>
+      <Box sx={{ textAlign: 'right' }}>
+        <Typography variant="body2" fontWeight={highlight ? 'bold' : 'normal'} color={highlight ? 'primary.main' : 'text.primary'}>
+          {value}
+        </Typography>
+        {caption && <Typography variant="caption" color="text.secondary" display="block">{caption}</Typography>}
+      </Box>
+    </Box>
+  );
+}
+
+const PROGRAM_TYPES = [
+  { id: 'utility',   label: 'Utility (Combat, Stealth, etc.)', isPersona: false },
+  { id: 'persona',   label: 'Persona Program (Bod/Evasion/Masking/Sensor)', isPersona: true },
+  { id: 'ic',        label: 'IC (Intrusion Countermeasure)', isPersona: false },
+  { id: 'agent',     label: 'Agent', isPersona: false },
+  { id: 'other',     label: 'Other', isPersona: false },
+];
+
+const HOST_COLORS = [
+  { id: 'none',   label: 'None (not using mainframe)' },
+  { id: 'blue',   label: 'Blue host',   mod: -1 },
+  { id: 'green',  label: 'Green host',  mod: -2 },
+  { id: 'orange', label: 'Orange host', mod: -3 },
+  { id: 'red',    label: 'Red host',    mod: -4 },
+];
+
+const defaultState = {
+  // Character
+  skill: 6,
+  suiteRating: 0,
+  // Program
+  programType: 'utility',
+  programRating: 4,
+  multiplier: 3,
+  options: 0,
+  language: 'none',
+  // Programming conditions
+  doubleMem: false,
+  hostColor: 'none',
+  planSuccesses: 0,
+  teamMembers: 1,
+  reducedTime: false,
+  // Successes achieved on Programming Test (for task period)
+  programmingSuccesses: 3,
+  // Upgrade mode
+  upgradeMode: false,
+  oldRating: 3,
+};
+
+export default function ProgrammingCalculator() {
+  const [s, setS] = useState(defaultState);
+  const set = (k, v) => setS(d => ({ ...d, [k]: v }));
+
+  const programType = PROGRAM_TYPES.find(t => t.id === s.programType) ?? PROGRAM_TYPES[0];
+  const maxRating   = maxProgramRating(s.skill, programType.isPersona);
+  const rating      = Math.min(s.programRating, maxRating);
+  const sizeMp      = programSize(rating, s.multiplier);
+
+  // TN calculation
+  const baseTN  = rating;
+  let tnMod = 0;
+  if (s.doubleMem) tnMod -= 2;
+  if (s.planSuccesses > 0) tnMod -= s.planSuccesses;
+  const host = HOST_COLORS.find(h => h.id === s.hostColor);
+  if (host?.mod) tnMod += host.mod;
+  const lang = ProgrammingLanguages.find(l => l.id === s.language);
+  if (lang?.id === 'mct_iconix') tnMod -= 1;
+  if (lang?.id === 'oblong')     tnMod -= 2;
+
+  const finalTN = Math.max(2, baseTN + tnMod);
+
+  // Suite complementary dice
+  const compDice = s.suiteRating > 0 ? suiteCompDice(s.suiteRating, s.skill) : 0;
+
+  // Time
+  const basedays    = s.upgradeMode
+    ? upgradeBaseTimeDays(rating, s.multiplier, Math.min(s.oldRating, rating - 1))
+    : baseTimeDays(sizeMp);
+  const taskDays    = taskPeriodDays(basedays, s.programmingSuccesses);
+
+  // Renraku Teng doubles base time
+  const effectiveBasedays = lang?.id === 'renraku' ? basedays * 2 : basedays;
+  const effectiveTaskDays = taskPeriodDays(effectiveBasedays, s.programmingSuccesses);
+
+  // Program plan
+  const planHrs    = planTimeHours(rating, s.options, s.multiplier);
+  const planMp     = planSizeMp(sizeMp);
+  const plantn     = planTN(rating, s.options);
+
+  // Bug test
+  const isMainframe = s.hostColor !== 'none';
+  const bugTN = bugTestTN(rating, s.skill, s.options, s.teamMembers, isMainframe, s.reducedTime, s.language);
+
+  // MachoDev reduces effective rating for display
+  const effectiveRating = lang?.id === 'machodev' ? rating - 1 : rating;
+
+  // Memory needed
+  const memNeeded = sizeMp;
+  const hasDoubleMem = s.doubleMem;
+
+  return (
+    <Box sx={{ p: 2, maxWidth: 1100 }}>
+      <Typography variant="h5" gutterBottom>
+        Programming Calculator
+        <Chip label="SR3 Matrix Rules" size="small" variant="outlined" sx={{ ml: 1, fontSize: '0.7rem' }} color="primary" />
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Calculate programming time, TNs and task periods for SR3 deckers. Source: <em>Matrix</em> pp. 76–81.
+      </Typography>
+
+      <Grid container spacing={2} sx={{ mt: 1 }}>
+
+        {/* ── Left column ─────────────────────────────────────────────── */}
+        <Grid item xs={12} md={7}>
+
+          {/* Character */}
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Character</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+              <TextField
+                label="Computer (Programming) Skill"
+                type="number" size="small" sx={{ width: 220 }}
+                value={s.skill}
+                onChange={e => set('skill', Math.max(1, Math.min(12, +e.target.value)))}
+                inputProps={{ min: 1, max: 12 }}
+              />
+              <Box>
+                <TextField
+                  label="Programming Suite Rating"
+                  type="number" size="small" sx={{ width: 180 }}
+                  value={s.suiteRating}
+                  onChange={e => set('suiteRating', Math.max(0, Math.min(10, +e.target.value)))}
+                  inputProps={{ min: 0, max: 10 }}
+                />
+                {s.suiteRating > 0 && (
+                  <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                    <Chip size="small" label={`${compDice} comp. dice`} color="secondary" />
+                    <Chip size="small" label={`Suite size: ${fmt(suiteSizeMp(s.suiteRating))} Mp`} />
+                  </Box>
+                )}
+                <Typography variant="caption" color="text.secondary" display="block">
+                  0 = no suite · max comp. dice = skill ({s.skill})
+                </Typography>
+              </Box>
+            </Box>
+          </Paper>
+
+          {/* Program Design */}
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Program Design</Typography>
+
+            {/* Mode toggle */}
+            <Box sx={{ mb: 2 }}>
+              <ToggleButtonGroup value={s.upgradeMode ? 'upgrade' : 'new'} exclusive size="small"
+                onChange={(_, v) => { if (v) set('upgradeMode', v === 'upgrade'); }}>
+                <ToggleButton value="new">New Program</ToggleButton>
+                <ToggleButton value="upgrade">Upgrade Existing</ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+              <FormControl size="small" sx={{ minWidth: 260 }}>
+                <InputLabel>Program Type</InputLabel>
+                <Select value={s.programType} label="Program Type"
+                  onChange={e => set('programType', e.target.value)}>
+                  {PROGRAM_TYPES.map(t => (
+                    <MenuItem key={t.id} value={t.id}>{t.label}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <Box>
+                <TextField
+                  label="Program Rating"
+                  type="number" size="small" sx={{ width: 140 }}
+                  value={s.programRating}
+                  onChange={e => set('programRating', Math.max(1, Math.min(14, +e.target.value)))}
+                  inputProps={{ min: 1, max: 14 }}
+                  error={s.programRating > maxRating}
+                  helperText={s.programRating > maxRating ? `Capped at ${maxRating} (your skill)` : `Max: ${maxRating}`}
+                />
+              </Box>
+
+              <Box>
+                <TextField
+                  label="Multiplier (1–10)"
+                  type="number" size="small" sx={{ width: 140 }}
+                  value={s.multiplier}
+                  onChange={e => set('multiplier', Math.max(1, Math.min(10, +e.target.value)))}
+                  inputProps={{ min: 1, max: 10 }}
+                />
+              </Box>
+
+              <Box>
+                <TextField
+                  label="Program Options"
+                  type="number" size="small" sx={{ width: 140 }}
+                  value={s.options}
+                  onChange={e => set('options', Math.max(0, +e.target.value))}
+                  inputProps={{ min: 0 }}
+                />
+                <Typography variant="caption" color="text.secondary" display="block">
+                  Each option +1 to plan TN
+                </Typography>
+              </Box>
+
+              {s.upgradeMode && (
+                <Box>
+                  <TextField
+                    label="Current (old) Rating"
+                    type="number" size="small" sx={{ width: 160 }}
+                    value={s.oldRating}
+                    onChange={e => set('oldRating', Math.max(1, Math.min(rating - 1, +e.target.value)))}
+                    inputProps={{ min: 1, max: Math.max(1, rating - 1) }}
+                  />
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    Must be less than new rating ({rating})
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Chip color="primary" label={`Program size: ${fmt(sizeMp)} Mp`} />
+              <Chip label={`Memory required: ${fmt(memNeeded)} Mp`} />
+              <Chip label={`Base time: ${fmtDays(effectiveBasedays)}`} />
+              {lang?.id === 'renraku' && (
+                <Chip color="warning" size="small" label="Renraku Teng ×2 base time" />
+              )}
+            </Box>
+          </Paper>
+
+          {/* Programming Conditions */}
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Programming Conditions</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+
+              <Box>
+                <TextField
+                  label="Program Plan Successes"
+                  type="number" size="small" sx={{ width: 200 }}
+                  value={s.planSuccesses}
+                  onChange={e => set('planSuccesses', Math.max(0, +e.target.value))}
+                  inputProps={{ min: 0 }}
+                />
+                <Typography variant="caption" color="text.secondary" display="block">
+                  Each success −1 to Programming TN
+                </Typography>
+              </Box>
+
+              <Box>
+                <TextField
+                  label="Team Members (total)"
+                  type="number" size="small" sx={{ width: 180 }}
+                  value={s.teamMembers}
+                  onChange={e => set('teamMembers', Math.max(1, +e.target.value))}
+                  inputProps={{ min: 1 }}
+                />
+                <Typography variant="caption" color="text.secondary" display="block">
+                  1 = solo; &gt;1 = team programming
+                </Typography>
+              </Box>
+
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel>Mainframe Host</InputLabel>
+                <Select value={s.hostColor} label="Mainframe Host"
+                  onChange={e => set('hostColor', e.target.value)}>
+                  {HOST_COLORS.map(h => (
+                    <MenuItem key={h.id} value={h.id}>
+                      {h.label}{h.mod != null ? ` (${h.mod > 0 ? '+' : ''}${h.mod} TN)` : ''}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel>Programming Language</InputLabel>
+                <Select value={s.language} label="Programming Language"
+                  onChange={e => set('language', e.target.value)}>
+                  {ProgrammingLanguages.map(l => (
+                    <MenuItem key={l.id} value={l.id}>
+                      {l.label}
+                      {l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0 }}>
+              <FormControlLabel
+                control={<Checkbox checked={s.doubleMem} onChange={e => set('doubleMem', e.target.checked)} />}
+                label={<>Computer has double the required memory <InfoTip text="Computer has ≥ 2× the program size in both active and storage memory. Grants −2 TN." /></>}
+              />
+              <FormControlLabel
+                control={<Checkbox checked={s.reducedTime} onChange={e => set('reducedTime', e.target.checked)} />}
+                label={<>Used optional rule to reduce base time <InfoTip text="Optional rule allowing reduced base time. Adds +3 to Bug Test TN." /></>}
+              />
+            </Box>
+
+            {lang && lang.id !== 'none' && lang.otherEffect && (
+              <Alert severity="info" sx={{ mt: 1 }} icon={false}>
+                <strong>{lang.label}:</strong> {lang.otherEffect}
+              </Alert>
+            )}
+          </Paper>
+
+          {/* Program Plan Helper */}
+          <Accordion variant="outlined" sx={{ mb: 2 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="subtitle2">Program Plan Helper</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>
+                (create a plan to reduce programming TN — Matrix p.78)
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                A program plan reduces the Programming TN by 1 per success. Uses
+                Combat Utility Design / Operational Utility Design / Cyberterminal Code Design
+                skill against TN {plantn}.
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                <Chip label={`Plan TN: ${plantn}`} color="primary" />
+                <Chip label={`Plan creation time: ${fmt(planHrs)} hrs (${(planHrs / 8).toFixed(1)} days)`} />
+                <Chip label={`Plan size: ${fmt(planMp)} Mp`} />
+              </Box>
+              <Typography variant="caption" color="text.secondary">
+                Plan TN = 4 base
+                {rating <= 4 ? ' −1 (rating 1–4)' : rating >= 10 ? ' +1 (rating 10+)' : ''}
+                {s.options > 0 ? ` +${s.options} (${s.options} option${s.options > 1 ? 's' : ''})` : ''}
+                {' = '}{plantn}
+              </Typography>
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                Plan time = (rating {rating} + {s.options} options) × multiplier {s.multiplier} = {planHrs} hrs
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+
+          {/* Bug Test (optional rule) */}
+          <Accordion variant="outlined" sx={{ mb: 2 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="subtitle2">Bug Test (Optional Rule)</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>
+                (Matrix p.81 — open test each time program is used)
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                Every time the program is run, make an Open Test using Computer (Programming).
+                Bugs appear on the n-th use (n = Occurrence factor from rolls). TN modifiers:
+              </Typography>
+              <TableContainer component={Paper} variant="outlined">
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Situation</TableCell>
+                      <TableCell align="right">Modifier</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>Program difficulty (−(Rating+2))</TableCell>
+                      <TableCell align="right">{-(rating + 2)}</TableCell>
+                    </TableRow>
+                    {s.options > 0 && (
+                      <TableRow>
+                        <TableCell>Options (−(options+2))</TableCell>
+                        <TableCell align="right">{-(s.options + 2)}</TableCell>
+                      </TableRow>
+                    )}
+                    {s.teamMembers > 1 && (
+                      <TableRow>
+                        <TableCell>Team ({s.teamMembers} members)</TableCell>
+                        <TableCell align="right">{-(s.teamMembers + 2)}</TableCell>
+                      </TableRow>
+                    )}
+                    {isMainframe && (
+                      <TableRow>
+                        <TableCell>Used mainframe</TableCell>
+                        <TableCell align="right">+2</TableCell>
+                      </TableRow>
+                    )}
+                    {s.reducedTime && (
+                      <TableRow>
+                        <TableCell>Reduced base time</TableCell>
+                        <TableCell align="right">+3</TableCell>
+                      </TableRow>
+                    )}
+                    {lang && lang.id !== 'none' && lang.bugMod !== 0 && (
+                      <TableRow>
+                        <TableCell>{lang.label} (language)</TableCell>
+                        <TableCell align="right">
+                          {lang.id === 'novatech'
+                            ? `${lang.bugMod} × ${s.options} options = ${lang.bugMod * s.options}`
+                            : lang.bugMod}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    <TableRow sx={{ bgcolor: 'action.hover' }}>
+                      <TableCell><strong>Total Bug TN modifier</strong></TableCell>
+                      <TableCell align="right"><strong>{bugTN >= 0 ? '+' : ''}{bugTN}</strong></TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                GM rolls 2D6 ÷ base time (round up) on failure. That number = minimum uses before bugs manifest.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+
+        </Grid>
+
+        {/* ── Right column: results ───────────────────────────────────── */}
+        <Grid item xs={12} md={5}>
+          <Box sx={{ position: 'sticky', top: 80 }}>
+
+            {/* Programming Test */}
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Computer (Programming) vs TN {finalTN}
+                {compDice > 0 && ` · +${compDice} comp. dice from suite`}
+              </Typography>
+
+              <Box sx={{ mb: 1 }}>
+                <StatRow label="Base TN (program rating)" value={baseTN} />
+                {s.doubleMem && <StatRow label="Double memory" value="−2" />}
+                {s.planSuccesses > 0 && <StatRow label={`Plan successes (×${s.planSuccesses})`} value={`−${s.planSuccesses}`} />}
+                {host?.mod && <StatRow label={host.label} value={host.mod} />}
+                {lang?.id === 'mct_iconix' && <StatRow label="MCT Iconix 7" value="−1" />}
+                {lang?.id === 'oblong' && <StatRow label="Oblong" value="−2" />}
+              </Box>
+
+              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+                <Chip color="primary" label={`Final TN: ${finalTN}`} />
+                {compDice > 0 && <Chip color="secondary" label={`+${compDice} comp. dice`} />}
+                {lang?.id === 'machodev' && <Chip color="warning" size="small" label={`Effective rating: ${effectiveRating} (MachoDev −1)`} />}
+              </Box>
+            </Paper>
+
+            {/* Task Period */}
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
+              <Box sx={{ mb: 1 }}>
+                <TextField
+                  label="Successes on Programming Test"
+                  type="number" size="small" fullWidth
+                  value={s.programmingSuccesses}
+                  onChange={e => set('programmingSuccesses', Math.max(1, +e.target.value))}
+                  inputProps={{ min: 1 }}
+                  sx={{ mb: 1 }}
+                />
+                {s.teamMembers > 1 && (
+                  <Alert severity="info" sx={{ mb: 1, py: 0.5 }} icon={false}>
+                    Team: roll dice equal to average Computer (Programming) skill (round down).
+                    Each member works min {fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days.
+                  </Alert>
+                )}
+              </Box>
+              <StatRow label="Base time" value={fmtDays(effectiveBasedays)} />
+              <StatRow label="Programming successes" value={s.programmingSuccesses} />
+              <StatRow
+                label="Task period"
+                value={effectiveTaskDays ? fmtDays(effectiveTaskDays) : '—'}
+                highlight
+                caption={effectiveTaskDays ? `${fmt(effectiveTaskDays * 8)} hrs total work` : undefined}
+              />
+              {s.teamMembers > 1 && effectiveTaskDays && (
+                <StatRow
+                  label={`Min days per member (÷${s.teamMembers + 1})`}
+                  value={`${fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days`}
+                />
+              )}
+            </Paper>
+
+            {/* Summary chips */}
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Program Summary</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                <Chip size="small" color="primary" label={`Rating ${rating}`} />
+                <Chip size="small" label={`×${s.multiplier} multiplier`} />
+                <Chip size="small" label={`${fmt(sizeMp)} Mp`} />
+                <Chip size="small" label={`TN ${finalTN}`} />
+                {compDice > 0 && <Chip size="small" color="secondary" label={`+${compDice} comp dice`} />}
+                {s.options > 0 && <Chip size="small" label={`${s.options} option${s.options > 1 ? 's' : ''}`} />}
+                {s.upgradeMode && <Chip size="small" color="warning" label={`Upgrade from ${s.oldRating}`} />}
+                {lang && lang.id !== 'none' && <Chip size="small" label={lang.label} />}
+                {s.hostColor !== 'none' && <Chip size="small" label={HOST_COLORS.find(h => h.id === s.hostColor)?.label} />}
+              </Box>
+            </Paper>
+
+            {/* Quick Reference */}
+            <Accordion variant="outlined">
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle2">Quick Reference</Typography>
+              </AccordionSummary>
+              <AccordionDetails sx={{ p: 1 }}>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Program Size:</strong> Rating² × Multiplier (Mp)</Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Size in days (1 day = 8 hrs work)</Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Period:</strong> Base time ÷ successes (days)</Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = Computer (Programming) skill{programType.isPersona ? ' × 1.5 (round down) for persona' : ''}</Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Suite:</strong> Rating² × 15 Mp · provides comp. dice (capped by skill)</Typography>
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Memory:</strong> Computer must have program size in both active and storage memory. Double = −2 TN.</Typography>
+                <Divider sx={{ my: 1 }} />
+                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Programming Suite Table:</strong></Typography>
+                {[1,2,3,4,5,6,7,8,9,10].map(r => (
+                  <Typography key={r} variant="caption" display="block" sx={{ pl: 1 }}>
+                    Rating {r}: {r*r*15} Mp
+                  </Typography>
+                ))}
+              </AccordionDetails>
+            </Accordion>
+
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/ProgrammingCalculator.js
+++ b/src/components/ProgrammingCalculator.js
@@ -297,12 +297,15 @@ function FrameAgentCalculator({ skill, compDice: suiteComp }) {
             )}
           </Box>
 
-          <FormControl size="small" sx={{ minWidth: 220, mb: 2 }}>
-            <InputLabel>Programming Language</InputLabel>
-            <Select value={f.language} label="Programming Language" onChange={e => ff('language', e.target.value)}>
-              {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
-            </Select>
-          </FormControl>
+          <Box sx={{ mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel>Programming Language</InputLabel>
+              <Select value={f.language} label="Programming Language" onChange={e => ff('language', e.target.value)}>
+                {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
+              </Select>
+            </FormControl>
+            {(() => { const l = ProgrammingLanguages.find(x => x.id === f.language); return l?.description ? <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>{l.description}</Typography> : null; })()}
+          </Box>
 
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
             <Chip color="primary" label={`Actual size: ${fmt(actualSizeMp)} Mp (memory)`} />
@@ -454,12 +457,15 @@ function WormsCalculator({ skill, compDice: suiteComp }) {
             )}
           </Box>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
-            <FormControl size="small" sx={{ minWidth: 220 }}>
-              <InputLabel>Programming Language</InputLabel>
-              <Select value={w.language} label="Programming Language" onChange={e => wf('language', e.target.value)}>
-                {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
-              </Select>
-            </FormControl>
+            <Box>
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <InputLabel>Programming Language</InputLabel>
+                <Select value={w.language} label="Programming Language" onChange={e => wf('language', e.target.value)}>
+                  {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
+                </Select>
+              </FormControl>
+              {(() => { const l = ProgrammingLanguages.find(x => x.id === w.language); return l?.description ? <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>{l.description}</Typography> : null; })()}
+            </Box>
             <FormControl size="small" sx={{ minWidth: 200 }}>
               <InputLabel>Mainframe Host</InputLabel>
               <Select value={w.hostColor} label="Mainframe Host" onChange={e => wf('hostColor', e.target.value)}>
@@ -909,16 +915,19 @@ export default function ProgrammingCalculator() {
                     ))}
                   </Select>
                 </FormControl>
-                <FormControl size="small" sx={{ minWidth: 220 }}>
-                  <InputLabel>Programming Language</InputLabel>
-                  <Select value={s.language} label="Programming Language" onChange={e => set('language', e.target.value)}>
-                    {ProgrammingLanguages.map(l => (
-                      <MenuItem key={l.id} value={l.id}>
-                        {l.label}{l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                <Box>
+                  <FormControl size="small" sx={{ minWidth: 220 }}>
+                    <InputLabel>Programming Language</InputLabel>
+                    <Select value={s.language} label="Programming Language" onChange={e => set('language', e.target.value)}>
+                      {ProgrammingLanguages.map(l => (
+                        <MenuItem key={l.id} value={l.id}>
+                          {l.label}{l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  {lang?.description && <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>{lang.description}</Typography>}
+                </Box>
               </Box>
               <Box>
                 <FormControlLabel
@@ -930,11 +939,6 @@ export default function ProgrammingCalculator() {
                   label={<>Used optional rule to reduce base time <InfoTip text="Adds +3 to Bug Test TN." /></>}
                 />
               </Box>
-              {lang && lang.id !== 'none' && lang.otherEffect && (
-                <Alert severity="info" sx={{ mt: 1 }} icon={false}>
-                  <strong>{lang.label}:</strong> {lang.otherEffect}
-                </Alert>
-              )}
             </Paper>
 
             <Accordion variant="outlined" sx={{ mb: 2 }}>

--- a/src/components/ProgrammingCalculator.js
+++ b/src/components/ProgrammingCalculator.js
@@ -1,32 +1,33 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import {
   Box, Typography, TextField, Paper, Chip, Alert,
   FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Accordion, AccordionSummary, AccordionDetails, Divider, Tooltip, Grid,
-  ToggleButton, ToggleButtonGroup
+  ToggleButton, ToggleButtonGroup, Tabs, Tab,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   programSize, maxProgramRating, suiteSizeMp, suiteCompDice,
-  baseTimeDays, baseTimeHours, taskPeriodDays, taskPeriodHours,
-  ProgrammingModifiers, planTimeHours, planSizeMp, planTN,
-  ProgrammingLanguages, bugTestTN, upgradeBaseTimeDays
+  baseTimeDays, taskPeriodDays,
+  planTimeHours, planSizeMp, planTN,
+  ProgrammingLanguages, bugTestTN, upgradeBaseTimeDays,
+  ProgramOptions, calcDesignRating, calcDesignSize, calcActualSize,
+  FrameAgentTypes, maxFrameRating, framePersonaPoints, frameFramePoints,
+  WormTypes, ICPrograms,
 } from '../data/SR3/ProgrammingRules';
 
-function fmt(n, unit = '') {
+// ── Shared helpers ────────────────────────────────────────────────────────────
+function fmt(n) {
   if (n == null) return '—';
-  return `${Math.round(n).toLocaleString()}${unit ? ' ' + unit : ''}`;
+  return Math.round(n).toLocaleString();
 }
-
 function fmtDays(days) {
   if (days == null) return '—';
-  const h = days * 8;
   if (days === 1) return '1 day (8 hrs)';
-  return `${fmt(days)} days (${fmt(h)} hrs)`;
+  return `${fmt(days)} days (${fmt(days * 8)} hrs)`;
 }
-
 function InfoTip({ text }) {
   return (
     <Tooltip title={text} placement="right">
@@ -34,7 +35,6 @@ function InfoTip({ text }) {
     </Tooltip>
   );
 }
-
 function StatRow({ label, value, highlight, caption }) {
   return (
     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
@@ -49,13 +49,46 @@ function StatRow({ label, value, highlight, caption }) {
   );
 }
 
-const PROGRAM_TYPES = [
-  { id: 'utility',   label: 'Utility (Combat, Stealth, etc.)', isPersona: false },
-  { id: 'persona',   label: 'Persona Program (Bod/Evasion/Masking/Sensor)', isPersona: true },
-  { id: 'ic',        label: 'IC (Intrusion Countermeasure)', isPersona: false },
-  { id: 'agent',     label: 'Agent', isPersona: false },
-  { id: 'other',     label: 'Other', isPersona: false },
-];
+function OptionChips({ availableOptions, selectedOptions, onToggle, onRateChange }) {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+      {availableOptions.map(opt => {
+        const sel = selectedOptions.find(o => o.id === opt.id);
+        const isSelected = !!sel;
+        const drLabel = opt.designRatingMod != null && opt.designRatingMod !== 0
+          ? (opt.designRatingMod > 0 ? `+${opt.designRatingMod}` : `${opt.designRatingMod}`)
+          : '';
+        const perLabel = opt.designRatingModPerPoint
+          ? (opt.designRatingModPerPoint > 0 ? `+${opt.designRatingModPerPoint}/pt` : `${opt.designRatingModPerPoint}/pt`)
+          : '';
+        const modLabel = [drLabel, perLabel].filter(Boolean).join(' ');
+        return (
+          <Box key={opt.id} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Tooltip title={opt.notes} placement="top" arrow>
+              <Chip
+                label={`${opt.label}${modLabel ? ` (DR ${modLabel})` : ' (special)'}`}
+                size="small"
+                variant={isSelected ? 'filled' : 'outlined'}
+                color={isSelected ? 'primary' : 'default'}
+                onClick={() => onToggle(opt.id)}
+                sx={{ cursor: 'pointer' }}
+              />
+            </Tooltip>
+            {isSelected && opt.hasOptionRating && (
+              <TextField
+                label={opt.optionRatingLabel}
+                type="number" size="small" sx={{ width: 160 }}
+                value={sel.optionRating}
+                onChange={e => onRateChange(opt.id, Math.max(1, +e.target.value))}
+                inputProps={{ min: 1, max: 10 }}
+              />
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
 
 const HOST_COLORS = [
   { id: 'none',   label: 'None (not using mainframe)' },
@@ -65,40 +98,599 @@ const HOST_COLORS = [
   { id: 'red',    label: 'Red host',    mod: -4 },
 ];
 
+const PROGRAM_TYPES = [
+  { id: 'utility', label: 'Utility (Combat, Stealth, etc.)', isPersona: false },
+  { id: 'persona', label: 'Persona Program (Bod/Evasion/Masking/Sensor)', isPersona: true },
+  { id: 'ic',      label: 'IC (Intrusion Countermeasure)', isPersona: false },
+  { id: 'agent',   label: 'Agent', isPersona: false },
+  { id: 'other',   label: 'Other', isPersona: false },
+];
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Frames & Agents tab
+// ═════════════════════════════════════════════════════════════════════════════
+
+const frameDefault = {
+  frameType: 'smart', coreRating: 4,
+  bod: 1, evasion: 1, masking: 1, sensor: 1,
+  pilotRating: 0, initBonus: 0, utilityPayload: 0,
+  selectedOptions: [], programmingSuccesses: 3, language: 'none',
+};
+
+function FrameAgentCalculator({ skill, compDice: suiteComp }) {
+  const [f, setF] = useState(frameDefault);
+  const ff = (k, v) => setF(d => ({ ...d, [k]: v }));
+
+  const frameType = FrameAgentTypes.find(t => t.id === f.frameType) ?? FrameAgentTypes[0];
+  const maxRating = maxFrameRating(skill, f.frameType);
+  const rating = Math.min(f.coreRating, maxRating);
+
+  const personaPoints = framePersonaPoints(rating, f.frameType);
+  const fpTotal = frameFramePoints(rating, f.frameType);
+  const personaSpent = f.bod + f.evasion + f.masking + f.sensor;
+  const fpSpent = f.pilotRating * 2 + f.initBonus * 3 + f.utilityPayload;
+  const personaLeft = personaPoints - personaSpent;
+  const fpLeft = fpTotal - fpSpent;
+
+  const frameOpts = frameType.isIC
+    ? ProgramOptions.filter(o =>
+        (o.availableFor === 'ic' && !['ic_cascading', 'ic_party_cluster', 'ic_trap'].includes(o.id))
+        || ['optimization', 'squeeze'].includes(o.id)
+      )
+    : ProgramOptions.filter(o => ['optimization', 'squeeze'].includes(o.id));
+
+  function toggleOpt(id) {
+    setF(d => {
+      const has = d.selectedOptions.find(o => o.id === id);
+      return has
+        ? { ...d, selectedOptions: d.selectedOptions.filter(o => o.id !== id) }
+        : { ...d, selectedOptions: [...d.selectedOptions, { id, optionRating: 1 }] };
+    });
+  }
+  function setOptRating(id, val) {
+    setF(d => ({ ...d, selectedOptions: d.selectedOptions.map(o => o.id === id ? { ...o, optionRating: val } : o) }));
+  }
+
+  const actualSizeMp = calcActualSize(rating, frameType.sizeMult, f.selectedOptions);
+  const designSizeMp = calcDesignSize(rating, frameType.sizeMult, f.selectedOptions);
+  const designRating = calcDesignRating(rating, f.selectedOptions);
+  const lang = ProgrammingLanguages.find(l => l.id === f.language);
+  const baseDays = baseTimeDays(designSizeMp);
+  const effectiveBaseDays = lang?.id === 'renraku' ? baseDays * 2 : baseDays;
+  const taskDays = taskPeriodDays(effectiveBaseDays, f.programmingSuccesses);
+  const tnMod = (f.language === 'mct_iconix' ? -1 : 0) + (f.language === 'oblong' ? -2 : 0);
+  const finalTN = Math.max(2, rating + tnMod);
+  const attrCap = rating;
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={7}>
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Frame / Agent Design</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Type</InputLabel>
+              <Select value={f.frameType} label="Type" onChange={e => ff('frameType', e.target.value)}>
+                {FrameAgentTypes.map(t => <MenuItem key={t.id} value={t.id}>{t.label}</MenuItem>)}
+              </Select>
+            </FormControl>
+            <Box>
+              <TextField
+                label="Core Rating"
+                type="number" size="small" sx={{ width: 130 }}
+                value={f.coreRating}
+                onChange={e => ff('coreRating', Math.max(1, Math.min(20, +e.target.value)))}
+                inputProps={{ min: 1, max: 20 }}
+                error={f.coreRating > maxRating}
+                helperText={f.coreRating > maxRating ? `Capped at ${maxRating}` : `Max: ${maxRating}`}
+              />
+            </Box>
+          </Box>
+
+          {frameType.notes && (
+            <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+              <Typography variant="caption">{frameType.notes}</Typography>
+            </Alert>
+          )}
+
+          {/* Persona Points */}
+          {frameType.hasPersona && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>
+                Persona Attributes
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                  {personaPoints} points · max {attrCap} per attribute · {Math.max(0, personaLeft)} remaining
+                </Typography>
+              </Typography>
+              {personaLeft < 0 && <Alert severity="error" sx={{ mb: 1, py: 0.5 }} icon={false}>Over-allocated by {-personaLeft} points — unused points are lost!</Alert>}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                {[['bod','Bod'],['evasion','Evasion'],['masking','Masking'],['sensor','Sensor']].map(([k, lbl]) => (
+                  <TextField key={k}
+                    label={lbl} type="number" size="small" sx={{ width: 90 }}
+                    value={f[k]}
+                    onChange={e => ff(k, Math.max(0, Math.min(attrCap, +e.target.value)))}
+                    inputProps={{ min: 0, max: attrCap }}
+                    error={f[k] > attrCap}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {/* Frame Points */}
+          {fpTotal > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>
+                Frame Points
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                  {fpTotal} available · {fpSpent} spent · {Math.max(0, fpLeft)} remaining
+                </Typography>
+              </Typography>
+              {fpLeft < 0 && <Alert severity="error" sx={{ mb: 1, py: 0.5 }} icon={false}>Over-allocated by {-fpLeft} Frame Points!</Alert>}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                {frameType.hasPilot && (
+                  <Box>
+                    <TextField
+                      label={`Pilot Rating (${f.pilotRating * 2} FP)`}
+                      type="number" size="small" sx={{ width: 170 }}
+                      value={f.pilotRating}
+                      onChange={e => ff('pilotRating', Math.max(0, Math.min(skill, +e.target.value)))}
+                      inputProps={{ min: 0, max: skill }}
+                    />
+                    <Typography variant="caption" color="text.secondary" display="block">2 FP/die · max {skill}</Typography>
+                  </Box>
+                )}
+                {frameType.maxInitBonusDice > 0 && (
+                  <Box>
+                    <TextField
+                      label={`Init Bonus Dice (${f.initBonus * 3} FP)`}
+                      type="number" size="small" sx={{ width: 170 }}
+                      value={f.initBonus}
+                      onChange={e => ff('initBonus', Math.max(0, Math.min(frameType.maxInitBonusDice, +e.target.value)))}
+                      inputProps={{ min: 0, max: frameType.maxInitBonusDice }}
+                    />
+                    <Typography variant="caption" color="text.secondary" display="block">3 FP/die · max {frameType.maxInitBonusDice}D6</Typography>
+                  </Box>
+                )}
+                <Box>
+                  <TextField
+                    label={`Utility Payload (${f.utilityPayload} FP)`}
+                    type="number" size="small" sx={{ width: 170 }}
+                    value={f.utilityPayload}
+                    onChange={e => ff('utilityPayload', Math.max(0, +e.target.value))}
+                    inputProps={{ min: 0 }}
+                  />
+                  <Typography variant="caption" color="text.secondary" display="block">1 FP/point</Typography>
+                </Box>
+              </Box>
+            </Box>
+          )}
+
+          {/* IC Payload */}
+          {frameType.isIC && (
+            <Box sx={{ mb: 2 }}>
+              <Chip color="secondary" label={`IC Payload: ${rating * 2} (rating ${rating} × 2)`} />
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                Hacking Pool = host Security Code (Blue=0, Green=1, Orange=2, Red=3)
+              </Typography>
+            </Box>
+          )}
+
+          {/* Options */}
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Options
+              <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                {frameType.isIC ? 'IC options (excl. Cascading/Party Cluster/Trap) + Optimization + Squeeze' : 'Optimization and Squeeze only'}
+              </Typography>
+            </Typography>
+            <OptionChips
+              availableOptions={frameOpts}
+              selectedOptions={f.selectedOptions}
+              onToggle={toggleOpt}
+              onRateChange={setOptRating}
+            />
+            {f.selectedOptions.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                <Chip size="small" color="secondary" label={`Design rating: ${designRating} (base ${rating})`} />
+              </Box>
+            )}
+          </Box>
+
+          <FormControl size="small" sx={{ minWidth: 220, mb: 2 }}>
+            <InputLabel>Programming Language</InputLabel>
+            <Select value={f.language} label="Programming Language" onChange={e => ff('language', e.target.value)}>
+              {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
+            </Select>
+          </FormControl>
+
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <Chip color="primary" label={`Actual size: ${fmt(actualSizeMp)} Mp (memory)`} />
+            {designSizeMp !== actualSizeMp && (
+              <Chip label={`Design size: ${fmt(designSizeMp)} Mp (for time)`} variant="outlined" color="primary" />
+            )}
+            <Chip label={`Base time: ${fmtDays(effectiveBaseDays)}`} />
+          </Box>
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={5}>
+        <Box sx={{ position: 'sticky', top: 80 }}>
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Computer (Programming) vs TN {finalTN}{suiteComp > 0 ? ` · +${suiteComp} comp. dice` : ''}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              <Chip color="primary" label={`TN: ${finalTN} (core rating ${rating})`} />
+              {suiteComp > 0 && <Chip color="secondary" label={`+${suiteComp} comp. dice`} />}
+            </Box>
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
+            <TextField
+              label="Programming Test Successes"
+              type="number" size="small" fullWidth
+              value={f.programmingSuccesses}
+              onChange={e => ff('programmingSuccesses', Math.max(1, +e.target.value))}
+              inputProps={{ min: 1 }} sx={{ mb: 1 }}
+            />
+            <StatRow label="Base time" value={fmtDays(effectiveBaseDays)} />
+            <StatRow label="Task period" value={fmtDays(taskDays)} highlight />
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Summary</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Chip size="small" color="primary" label={`${frameType.label} Rating ${rating}`} />
+              <Chip size="small" label={`×${frameType.sizeMult} mult`} />
+              <Chip size="small" label={`${fmt(actualSizeMp)} Mp`} />
+              {frameType.hasPersona && <Chip size="small" label={`${personaSpent}/${personaPoints} persona pts`} color={personaLeft < 0 ? 'error' : 'default'} />}
+              {fpTotal > 0 && <Chip size="small" label={`${fpSpent}/${fpTotal} frame pts`} color={fpLeft < 0 ? 'error' : 'default'} />}
+              {frameType.hasPilot && f.pilotRating > 0 && <Chip size="small" label={`Pilot ${f.pilotRating}`} />}
+              {f.initBonus > 0 && <Chip size="small" label={`+${f.initBonus}D6 Init`} />}
+              {f.utilityPayload > 0 && <Chip size="small" label={`Payload ${f.utilityPayload}`} />}
+              {frameType.isIC && <Chip size="small" color="secondary" label={`IC Payload ${rating * 2}`} />}
+            </Box>
+          </Paper>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Worms tab
+// ═════════════════════════════════════════════════════════════════════════════
+
+const wormDefault = {
+  wormType: 'crashworm', wormRating: 4,
+  selectedOptions: [], programmingSuccesses: 3,
+  language: 'none', hostColor: 'none', doubleMem: false, planSuccesses: 0,
+};
+const WORM_OPT_IDS = ['optimization', 'selective'];
+
+function WormsCalculator({ skill, compDice: suiteComp }) {
+  const [w, setW] = useState(wormDefault);
+  const wf = (k, v) => setW(d => ({ ...d, [k]: v }));
+
+  const wormType = WormTypes.find(t => t.id === w.wormType) ?? WormTypes[0];
+  const rating = Math.min(w.wormRating, skill);
+  const wormOpts = ProgramOptions.filter(o => WORM_OPT_IDS.includes(o.id));
+
+  function toggleOpt(id) {
+    setW(d => {
+      const has = d.selectedOptions.find(o => o.id === id);
+      return has
+        ? { ...d, selectedOptions: d.selectedOptions.filter(o => o.id !== id) }
+        : { ...d, selectedOptions: [...d.selectedOptions, { id, optionRating: 1 }] };
+    });
+  }
+  function setOptRating(id, val) {
+    setW(d => ({ ...d, selectedOptions: d.selectedOptions.map(o => o.id === id ? { ...o, optionRating: val } : o) }));
+  }
+
+  const designRating = calcDesignRating(rating, w.selectedOptions);
+  const actualSizeMp = calcActualSize(rating, wormType.sizeMult, w.selectedOptions);
+  const designSizeMp = calcDesignSize(rating, wormType.sizeMult, w.selectedOptions);
+  const lang = ProgrammingLanguages.find(l => l.id === w.language);
+  const host = HOST_COLORS.find(h => h.id === w.hostColor);
+  let tnMod = 0;
+  if (w.doubleMem) tnMod -= 2;
+  if (w.planSuccesses > 0) tnMod -= w.planSuccesses;
+  if (host?.mod) tnMod += host.mod;
+  if (w.language === 'mct_iconix') tnMod -= 1;
+  if (w.language === 'oblong') tnMod -= 2;
+  const finalTN = Math.max(2, rating + tnMod);
+  const baseDays = baseTimeDays(designSizeMp);
+  const effectiveBaseDays = lang?.id === 'renraku' ? baseDays * 2 : baseDays;
+  const taskDays = taskPeriodDays(effectiveBaseDays, w.programmingSuccesses);
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={7}>
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Worm Design</Typography>
+          <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+            <Typography variant="caption">Worms use the same programming rules as other programs. Only Optimization and Selective options are available. (Matrix pp. 92–93)</Typography>
+          </Alert>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Worm Type</InputLabel>
+              <Select value={w.wormType} label="Worm Type" onChange={e => wf('wormType', e.target.value)}>
+                {WormTypes.map(t => <MenuItem key={t.id} value={t.id}>{t.label} (×{t.sizeMult})</MenuItem>)}
+              </Select>
+            </FormControl>
+            <Box>
+              <TextField
+                label="Worm Rating"
+                type="number" size="small" sx={{ width: 130 }}
+                value={w.wormRating}
+                onChange={e => wf('wormRating', Math.max(1, Math.min(14, +e.target.value)))}
+                inputProps={{ min: 1, max: 14 }}
+                error={w.wormRating > skill}
+                helperText={w.wormRating > skill ? `Capped at ${skill}` : `Max: ${skill}`}
+              />
+            </Box>
+          </Box>
+          {wormType.notes && (
+            <Alert severity="warning" sx={{ mb: 2 }} icon={false}>
+              <Typography variant="caption">{wormType.notes}</Typography>
+            </Alert>
+          )}
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Options (Optimization and Selective only)</Typography>
+            <OptionChips
+              availableOptions={wormOpts}
+              selectedOptions={w.selectedOptions}
+              onToggle={toggleOpt}
+              onRateChange={setOptRating}
+            />
+            {w.selectedOptions.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                <Chip size="small" color="secondary" label={`Design rating: ${designRating} (base ${rating})`} />
+              </Box>
+            )}
+          </Box>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel>Programming Language</InputLabel>
+              <Select value={w.language} label="Programming Language" onChange={e => wf('language', e.target.value)}>
+                {ProgrammingLanguages.map(l => <MenuItem key={l.id} value={l.id}>{l.label}</MenuItem>)}
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Mainframe Host</InputLabel>
+              <Select value={w.hostColor} label="Mainframe Host" onChange={e => wf('hostColor', e.target.value)}>
+                {HOST_COLORS.map(h => <MenuItem key={h.id} value={h.id}>{h.label}{h.mod != null ? ` (${h.mod > 0 ? '+' : ''}${h.mod} TN)` : ''}</MenuItem>)}
+              </Select>
+            </FormControl>
+          </Box>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            <Box>
+              <TextField
+                label="Plan Successes"
+                type="number" size="small" sx={{ width: 150 }}
+                value={w.planSuccesses}
+                onChange={e => wf('planSuccesses', Math.max(0, +e.target.value))}
+                inputProps={{ min: 0 }}
+              />
+              <Typography variant="caption" color="text.secondary" display="block">Each success −1 TN</Typography>
+            </Box>
+            <FormControlLabel
+              control={<Checkbox checked={w.doubleMem} onChange={e => wf('doubleMem', e.target.checked)} />}
+              label="Double memory (−2 TN)"
+            />
+          </Box>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <Chip color="primary" label={`Actual size: ${fmt(actualSizeMp)} Mp (memory)`} />
+            {designSizeMp !== actualSizeMp && (
+              <Chip label={`Design size: ${fmt(designSizeMp)} Mp (for time)`} variant="outlined" color="primary" />
+            )}
+            <Chip label={`Base time: ${fmtDays(effectiveBaseDays)}`} />
+          </Box>
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={5}>
+        <Box sx={{ position: 'sticky', top: 80 }}>
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>Computer (Programming) vs TN {finalTN}</Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              <Chip color="primary" label={`TN: ${finalTN}`} />
+              {suiteComp > 0 && <Chip color="secondary" label={`+${suiteComp} comp. dice`} />}
+            </Box>
+          </Paper>
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
+            <TextField
+              label="Programming Test Successes"
+              type="number" size="small" fullWidth
+              value={w.programmingSuccesses}
+              onChange={e => wf('programmingSuccesses', Math.max(1, +e.target.value))}
+              inputProps={{ min: 1 }} sx={{ mb: 1 }}
+            />
+            <StatRow label="Base time" value={fmtDays(effectiveBaseDays)} />
+            <StatRow label="Task period" value={fmtDays(taskDays)} highlight />
+          </Paper>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Summary</Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Chip size="small" color="primary" label={`${wormType.label} Rating ${rating}`} />
+              <Chip size="small" label={`×${wormType.sizeMult} mult`} />
+              <Chip size="small" label={`${fmt(actualSizeMp)} Mp`} />
+              <Chip size="small" label={`TN ${finalTN}`} />
+            </Box>
+          </Paper>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Command Sets tab
+// ═════════════════════════════════════════════════════════════════════════════
+
+function CommandSetsInfo({ skill }) {
+  const flyOps = Math.floor(skill / 2);
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={7}>
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Command Set Rules</Typography>
+          <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+            <Typography variant="caption">
+              A command set is a simple script that runs timed system operations on a host. Command sets do NOT load any utilities. (Matrix pp. 87, 94)
+            </Typography>
+          </Alert>
+
+          <Typography variant="subtitle2" gutterBottom>On-the-Fly Composition</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 3 }}>
+            <Chip color="primary" label={`Max operations: ${flyOps} (skill ${skill} ÷ 2, round down)`} />
+            <Chip label="3 Complex Actions to compose" />
+            <Chip label="No upload required" />
+          </Box>
+
+          <Typography variant="subtitle2" gutterBottom>Pre-Programmed Command Set</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+            <Chip color="primary" label={`Max operations: ${skill} (= Computer skill)`} />
+            <Chip label="Design size: 1D6 × 5 Mp (5–30 Mp)" />
+            <Chip label="Program in advance, then upload to host" />
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Base programming time = design size in days. Since design size is random (1D6 × 5 Mp), time varies:
+          </Typography>
+          <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Die Roll</TableCell>
+                  <TableCell align="center">Design Size</TableCell>
+                  <TableCell align="center">Base Time</TableCell>
+                  <TableCell align="center">3 successes</TableCell>
+                  <TableCell align="center">5 successes</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {[1,2,3,4,5,6].map(roll => {
+                  const mp = roll * 5;
+                  return (
+                    <TableRow key={roll}>
+                      <TableCell>{roll}</TableCell>
+                      <TableCell align="center">{mp} Mp</TableCell>
+                      <TableCell align="center">{fmtDays(mp)}</TableCell>
+                      <TableCell align="center">{fmtDays(Math.ceil(mp / 3))}</TableCell>
+                      <TableCell align="center">{fmtDays(Math.ceil(mp / 5))}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Activating a Command Set</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Perform a successful Analyze Subsystem operation, then a Null Operation to designate the command set as resident. The Security Value is modified based on time since the last operation.
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Each test uses a target number equal to the average rating of loaded operations (round up). No Hacking Pool allowed for these tests.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Once activated, the command set runs and counts down. If the host shuts down, any active command sets are lost. Use Crash Application to remove a command set early.
+          </Typography>
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={5}>
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Quick Reference (Skill {skill})</Typography>
+          <StatRow label="On-the-fly ops" value={`${flyOps} (skill ÷ 2)`} />
+          <StatRow label="Pre-programmed max ops" value={`${skill} (= skill)`} highlight />
+          <StatRow label="Design size" value="1D6 × 5 Mp (random)" />
+          <StatRow label="Avg base time" value="~17–18 days" />
+          <StatRow label="Composition (fly)" value="3 Complex Actions" />
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Per-Skill Reference</Typography>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Skill</TableCell>
+                  <TableCell align="center">Fly Ops</TableCell>
+                  <TableCell align="center">Max Pre-Prog</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {[3,4,5,6,7,8,9,10,12].map(s => (
+                  <TableRow key={s} sx={s === skill ? { bgcolor: 'action.selected' } : {}}>
+                    <TableCell>{s}{s === skill ? ' ★' : ''}</TableCell>
+                    <TableCell align="center">{Math.floor(s / 2)}</TableCell>
+                    <TableCell align="center">{s}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Main component
+// ═════════════════════════════════════════════════════════════════════════════
+
 const defaultState = {
-  // Character
-  skill: 6,
-  suiteRating: 0,
-  // Program
-  programType: 'utility',
-  programRating: 4,
-  multiplier: 3,
-  options: 0,
+  skill: 6, suiteRating: 0,
+  programType: 'utility', programRating: 4, multiplier: 3, icProgram: '',
+  selectedOptions: [],
   language: 'none',
-  // Programming conditions
-  doubleMem: false,
-  hostColor: 'none',
-  planSuccesses: 0,
-  teamMembers: 1,
-  reducedTime: false,
-  // Successes achieved on Programming Test (for task period)
+  doubleMem: false, hostColor: 'none', planSuccesses: 0, teamMembers: 1, reducedTime: false,
   programmingSuccesses: 3,
-  // Upgrade mode
-  upgradeMode: false,
-  oldRating: 3,
+  upgradeMode: false, oldRating: 3,
 };
 
 export default function ProgrammingCalculator() {
   const [s, setS] = useState(defaultState);
+  const [subTab, setSubTab] = useState(0);
   const set = (k, v) => setS(d => ({ ...d, [k]: v }));
 
   const programType = PROGRAM_TYPES.find(t => t.id === s.programType) ?? PROGRAM_TYPES[0];
   const maxRating   = maxProgramRating(s.skill, programType.isPersona);
   const rating      = Math.min(s.programRating, maxRating);
-  const sizeMp      = programSize(rating, s.multiplier);
+  const isUtility   = programType.id !== 'ic';
 
-  // TN calculation
-  const baseTN  = rating;
+  const availableOptions = ProgramOptions.filter(o =>
+    o.availableFor === 'both' ||
+    (isUtility ? o.availableFor === 'utility' : o.availableFor === 'ic')
+  );
+  const optionCount = s.selectedOptions.length;
+
+  function toggleOption(id) {
+    setS(d => {
+      const exists = d.selectedOptions.find(o => o.id === id);
+      return exists
+        ? { ...d, selectedOptions: d.selectedOptions.filter(o => o.id !== id) }
+        : { ...d, selectedOptions: [...d.selectedOptions, { id, optionRating: 1 }] };
+    });
+  }
+  function setOptionRating(id, val) {
+    setS(d => ({ ...d, selectedOptions: d.selectedOptions.map(o => o.id === id ? { ...o, optionRating: val } : o) }));
+  }
+
+  const designRating = calcDesignRating(rating, s.selectedOptions);
+  const designSizeMp = s.upgradeMode ? null : calcDesignSize(rating, s.multiplier, s.selectedOptions);
+  const actualSizeMp = calcActualSize(rating, s.multiplier, s.selectedOptions);
+
+  const baseTN = rating;
   let tnMod = 0;
   if (s.doubleMem) tnMod -= 2;
   if (s.planSuccesses > 0) tnMod -= s.planSuccesses;
@@ -107,37 +699,23 @@ export default function ProgrammingCalculator() {
   const lang = ProgrammingLanguages.find(l => l.id === s.language);
   if (lang?.id === 'mct_iconix') tnMod -= 1;
   if (lang?.id === 'oblong')     tnMod -= 2;
-
   const finalTN = Math.max(2, baseTN + tnMod);
 
-  // Suite complementary dice
   const compDice = s.suiteRating > 0 ? suiteCompDice(s.suiteRating, s.skill) : 0;
 
-  // Time
-  const basedays    = s.upgradeMode
+  const basedays = s.upgradeMode
     ? upgradeBaseTimeDays(rating, s.multiplier, Math.min(s.oldRating, rating - 1))
-    : baseTimeDays(sizeMp);
-  const taskDays    = taskPeriodDays(basedays, s.programmingSuccesses);
-
-  // Renraku Teng doubles base time
+    : baseTimeDays(designSizeMp ?? 0);
   const effectiveBasedays = lang?.id === 'renraku' ? basedays * 2 : basedays;
   const effectiveTaskDays = taskPeriodDays(effectiveBasedays, s.programmingSuccesses);
 
-  // Program plan
-  const planHrs    = planTimeHours(rating, s.options, s.multiplier);
-  const planMp     = planSizeMp(sizeMp);
-  const plantn     = planTN(rating, s.options);
+  const planHrs = planTimeHours(rating, optionCount, s.multiplier);
+  const planMp  = planSizeMp(designSizeMp ?? programSize(rating, s.multiplier));
+  const plantn  = planTN(rating, optionCount);
 
-  // Bug test
   const isMainframe = s.hostColor !== 'none';
-  const bugTN = bugTestTN(rating, s.skill, s.options, s.teamMembers, isMainframe, s.reducedTime, s.language);
-
-  // MachoDev reduces effective rating for display
+  const bugTN = bugTestTN(rating, s.skill, optionCount, s.teamMembers, isMainframe, s.reducedTime, s.language);
   const effectiveRating = lang?.id === 'machodev' ? rating - 1 : rating;
-
-  // Memory needed
-  const memNeeded = sizeMp;
-  const hasDoubleMem = s.doubleMem;
 
   return (
     <Box sx={{ p: 2, maxWidth: 1100 }}>
@@ -146,416 +724,365 @@ export default function ProgrammingCalculator() {
         <Chip label="SR3 Matrix Rules" size="small" variant="outlined" sx={{ ml: 1, fontSize: '0.7rem' }} color="primary" />
       </Typography>
       <Typography variant="body2" color="text.secondary" gutterBottom>
-        Calculate programming time, TNs and task periods for SR3 deckers. Source: <em>Matrix</em> pp. 76–81.
+        Calculate programming time, TNs and task periods for SR3 deckers. Source: <em>Matrix</em> pp. 76–94.
       </Typography>
 
-      <Grid container spacing={2} sx={{ mt: 1 }}>
-
-        {/* ── Left column ─────────────────────────────────────────────── */}
-        <Grid item xs={12} md={7}>
-
-          {/* Character */}
-          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-            <Typography variant="subtitle2" gutterBottom>Character</Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-              <TextField
-                label="Computer (Programming) Skill"
-                type="number" size="small" sx={{ width: 220 }}
-                value={s.skill}
-                onChange={e => set('skill', Math.max(1, Math.min(12, +e.target.value)))}
-                inputProps={{ min: 1, max: 12 }}
-              />
-              <Box>
-                <TextField
-                  label="Programming Suite Rating"
-                  type="number" size="small" sx={{ width: 180 }}
-                  value={s.suiteRating}
-                  onChange={e => set('suiteRating', Math.max(0, Math.min(10, +e.target.value)))}
-                  inputProps={{ min: 0, max: 10 }}
-                />
-                {s.suiteRating > 0 && (
-                  <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                    <Chip size="small" label={`${compDice} comp. dice`} color="secondary" />
-                    <Chip size="small" label={`Suite size: ${fmt(suiteSizeMp(s.suiteRating))} Mp`} />
-                  </Box>
-                )}
-                <Typography variant="caption" color="text.secondary" display="block">
-                  0 = no suite · max comp. dice = skill ({s.skill})
-                </Typography>
+      {/* Shared character section (all tabs use skill + suite) */}
+      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Typography variant="subtitle2" gutterBottom>Character</Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          <TextField
+            label="Computer (Programming) Skill"
+            type="number" size="small" sx={{ width: 220 }}
+            value={s.skill}
+            onChange={e => set('skill', Math.max(1, Math.min(12, +e.target.value)))}
+            inputProps={{ min: 1, max: 12 }}
+          />
+          <Box>
+            <TextField
+              label="Programming Suite Rating"
+              type="number" size="small" sx={{ width: 180 }}
+              value={s.suiteRating}
+              onChange={e => set('suiteRating', Math.max(0, Math.min(10, +e.target.value)))}
+              inputProps={{ min: 0, max: 10 }}
+            />
+            {s.suiteRating > 0 && (
+              <Box sx={{ mt: 0.5, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                <Chip size="small" label={`${compDice} comp. dice`} color="secondary" />
+                <Chip size="small" label={`Suite size: ${fmt(suiteSizeMp(s.suiteRating))} Mp`} />
               </Box>
-            </Box>
-          </Paper>
+            )}
+            <Typography variant="caption" color="text.secondary" display="block">
+              0 = no suite · max comp. dice = skill ({s.skill})
+            </Typography>
+          </Box>
+        </Box>
+      </Paper>
 
-          {/* Program Design */}
-          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-            <Typography variant="subtitle2" gutterBottom>Program Design</Typography>
+      {/* Sub-tabs */}
+      <Tabs
+        value={subTab}
+        onChange={(_, v) => setSubTab(v)}
+        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="Utility / IC Programs" />
+        <Tab label="Frames & Agents" />
+        <Tab label="Worms" />
+        <Tab label="Command Sets" />
+      </Tabs>
 
-            {/* Mode toggle */}
-            <Box sx={{ mb: 2 }}>
-              <ToggleButtonGroup value={s.upgradeMode ? 'upgrade' : 'new'} exclusive size="small"
-                onChange={(_, v) => { if (v) set('upgradeMode', v === 'upgrade'); }}>
-                <ToggleButton value="new">New Program</ToggleButton>
-                <ToggleButton value="upgrade">Upgrade Existing</ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
-              <FormControl size="small" sx={{ minWidth: 260 }}>
-                <InputLabel>Program Type</InputLabel>
-                <Select value={s.programType} label="Program Type"
-                  onChange={e => set('programType', e.target.value)}>
-                  {PROGRAM_TYPES.map(t => (
-                    <MenuItem key={t.id} value={t.id}>{t.label}</MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-
-              <Box>
-                <TextField
-                  label="Program Rating"
-                  type="number" size="small" sx={{ width: 140 }}
-                  value={s.programRating}
-                  onChange={e => set('programRating', Math.max(1, Math.min(14, +e.target.value)))}
-                  inputProps={{ min: 1, max: 14 }}
-                  error={s.programRating > maxRating}
-                  helperText={s.programRating > maxRating ? `Capped at ${maxRating} (your skill)` : `Max: ${maxRating}`}
-                />
+      {/* ── Programs tab ─────────────────────────────────────────────────── */}
+      {subTab === 0 && (
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Program Design</Typography>
+              <Box sx={{ mb: 2 }}>
+                <ToggleButtonGroup value={s.upgradeMode ? 'upgrade' : 'new'} exclusive size="small"
+                  onChange={(_, v) => { if (v) set('upgradeMode', v === 'upgrade'); }}>
+                  <ToggleButton value="new">New Program</ToggleButton>
+                  <ToggleButton value="upgrade">Upgrade Existing</ToggleButton>
+                </ToggleButtonGroup>
               </Box>
-
-              <Box>
-                <TextField
-                  label="Multiplier (1–10)"
-                  type="number" size="small" sx={{ width: 140 }}
-                  value={s.multiplier}
-                  onChange={e => set('multiplier', Math.max(1, Math.min(10, +e.target.value)))}
-                  inputProps={{ min: 1, max: 10 }}
-                />
-              </Box>
-
-              <Box>
-                <TextField
-                  label="Program Options"
-                  type="number" size="small" sx={{ width: 140 }}
-                  value={s.options}
-                  onChange={e => set('options', Math.max(0, +e.target.value))}
-                  inputProps={{ min: 0 }}
-                />
-                <Typography variant="caption" color="text.secondary" display="block">
-                  Each option +1 to plan TN
-                </Typography>
-              </Box>
-
-              {s.upgradeMode && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+                <FormControl size="small" sx={{ minWidth: 260 }}>
+                  <InputLabel>Program Type</InputLabel>
+                  <Select value={s.programType} label="Program Type" onChange={e => { set('programType', e.target.value); if (e.target.value !== 'ic') set('icProgram', ''); }}>
+                    {PROGRAM_TYPES.map(t => <MenuItem key={t.id} value={t.id}>{t.label}</MenuItem>)}
+                  </Select>
+                </FormControl>
                 <Box>
                   <TextField
-                    label="Current (old) Rating"
-                    type="number" size="small" sx={{ width: 160 }}
-                    value={s.oldRating}
-                    onChange={e => set('oldRating', Math.max(1, Math.min(rating - 1, +e.target.value)))}
-                    inputProps={{ min: 1, max: Math.max(1, rating - 1) }}
+                    label="Program Rating"
+                    type="number" size="small" sx={{ width: 140 }}
+                    value={s.programRating}
+                    onChange={e => set('programRating', Math.max(1, Math.min(14, +e.target.value)))}
+                    inputProps={{ min: 1, max: 14 }}
+                    error={s.programRating > maxRating}
+                    helperText={s.programRating > maxRating ? `Capped at ${maxRating} (your skill)` : `Max: ${maxRating}`}
                   />
-                  <Typography variant="caption" color="text.secondary" display="block">
-                    Must be less than new rating ({rating})
-                  </Typography>
                 </Box>
-              )}
-            </Box>
+                <Box>
+                  <TextField
+                    label="Multiplier (1–10)"
+                    type="number" size="small" sx={{ width: 140 }}
+                    value={s.multiplier}
+                    onChange={e => { set('multiplier', Math.max(1, Math.min(10, +e.target.value))); set('icProgram', ''); }}
+                    inputProps={{ min: 1, max: 10 }}
+                  />
+                </Box>
+                {s.programType === 'ic' && (
+                  <FormControl size="small" sx={{ minWidth: 220 }}>
+                    <InputLabel>IC Program Type</InputLabel>
+                    <Select
+                      value={s.icProgram}
+                      label="IC Program Type"
+                      onChange={e => {
+                        const prog = ICPrograms.find(p => p.id === e.target.value);
+                        set('icProgram', e.target.value);
+                        if (prog) set('multiplier', prog.sizeMult);
+                      }}
+                    >
+                      <MenuItem value=""><em>Custom multiplier</em></MenuItem>
+                      {ICPrograms.map(p => (
+                        <MenuItem key={p.id} value={p.id}>{p.label} (×{p.sizeMult})</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+                {s.upgradeMode && (
+                  <Box>
+                    <TextField
+                      label="Current (old) Rating"
+                      type="number" size="small" sx={{ width: 160 }}
+                      value={s.oldRating}
+                      onChange={e => set('oldRating', Math.max(1, Math.min(rating - 1, +e.target.value)))}
+                      inputProps={{ min: 1, max: Math.max(1, rating - 1) }}
+                    />
+                    <Typography variant="caption" color="text.secondary" display="block">
+                      Must be less than new rating ({rating})
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
 
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              <Chip color="primary" label={`Program size: ${fmt(sizeMp)} Mp`} />
-              <Chip label={`Memory required: ${fmt(memNeeded)} Mp`} />
-              <Chip label={`Base time: ${fmtDays(effectiveBasedays)}`} />
-              {lang?.id === 'renraku' && (
-                <Chip color="warning" size="small" label="Renraku Teng ×2 base time" />
-              )}
-            </Box>
-          </Paper>
-
-          {/* Programming Conditions */}
-          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-            <Typography variant="subtitle2" gutterBottom>Programming Conditions</Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
-
-              <Box>
-                <TextField
-                  label="Program Plan Successes"
-                  type="number" size="small" sx={{ width: 200 }}
-                  value={s.planSuccesses}
-                  onChange={e => set('planSuccesses', Math.max(0, +e.target.value))}
-                  inputProps={{ min: 0 }}
-                />
-                <Typography variant="caption" color="text.secondary" display="block">
-                  Each success −1 to Programming TN
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Program Options
+                  <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                    (Matrix pp. 83–86 — options change design rating &amp; size, NOT the programming TN)
+                  </Typography>
                 </Typography>
-              </Box>
-
-              <Box>
-                <TextField
-                  label="Team Members (total)"
-                  type="number" size="small" sx={{ width: 180 }}
-                  value={s.teamMembers}
-                  onChange={e => set('teamMembers', Math.max(1, +e.target.value))}
-                  inputProps={{ min: 1 }}
+                <OptionChips
+                  availableOptions={availableOptions}
+                  selectedOptions={s.selectedOptions}
+                  onToggle={toggleOption}
+                  onRateChange={setOptionRating}
                 />
-                <Typography variant="caption" color="text.secondary" display="block">
-                  1 = solo; &gt;1 = team programming
-                </Typography>
+                {s.selectedOptions.length > 0 && (
+                  <Box sx={{ mt: 1 }}>
+                    <Chip size="small" color="secondary" label={`Design rating: ${designRating} (base ${rating})`} />
+                  </Box>
+                )}
               </Box>
 
-              <FormControl size="small" sx={{ minWidth: 220 }}>
-                <InputLabel>Mainframe Host</InputLabel>
-                <Select value={s.hostColor} label="Mainframe Host"
-                  onChange={e => set('hostColor', e.target.value)}>
-                  {HOST_COLORS.map(h => (
-                    <MenuItem key={h.id} value={h.id}>
-                      {h.label}{h.mod != null ? ` (${h.mod > 0 ? '+' : ''}${h.mod} TN)` : ''}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-
-              <FormControl size="small" sx={{ minWidth: 220 }}>
-                <InputLabel>Programming Language</InputLabel>
-                <Select value={s.language} label="Programming Language"
-                  onChange={e => set('language', e.target.value)}>
-                  {ProgrammingLanguages.map(l => (
-                    <MenuItem key={l.id} value={l.id}>
-                      {l.label}
-                      {l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
-
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0 }}>
-              <FormControlLabel
-                control={<Checkbox checked={s.doubleMem} onChange={e => set('doubleMem', e.target.checked)} />}
-                label={<>Computer has double the required memory <InfoTip text="Computer has ≥ 2× the program size in both active and storage memory. Grants −2 TN." /></>}
-              />
-              <FormControlLabel
-                control={<Checkbox checked={s.reducedTime} onChange={e => set('reducedTime', e.target.checked)} />}
-                label={<>Used optional rule to reduce base time <InfoTip text="Optional rule allowing reduced base time. Adds +3 to Bug Test TN." /></>}
-              />
-            </Box>
-
-            {lang && lang.id !== 'none' && lang.otherEffect && (
-              <Alert severity="info" sx={{ mt: 1 }} icon={false}>
-                <strong>{lang.label}:</strong> {lang.otherEffect}
-              </Alert>
-            )}
-          </Paper>
-
-          {/* Program Plan Helper */}
-          <Accordion variant="outlined" sx={{ mb: 2 }}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="subtitle2">Program Plan Helper</Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>
-                (create a plan to reduce programming TN — Matrix p.78)
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                A program plan reduces the Programming TN by 1 per success. Uses
-                Combat Utility Design / Operational Utility Design / Cyberterminal Code Design
-                skill against TN {plantn}.
-              </Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
-                <Chip label={`Plan TN: ${plantn}`} color="primary" />
-                <Chip label={`Plan creation time: ${fmt(planHrs)} hrs (${(planHrs / 8).toFixed(1)} days)`} />
-                <Chip label={`Plan size: ${fmt(planMp)} Mp`} />
-              </Box>
-              <Typography variant="caption" color="text.secondary">
-                Plan TN = 4 base
-                {rating <= 4 ? ' −1 (rating 1–4)' : rating >= 10 ? ' +1 (rating 10+)' : ''}
-                {s.options > 0 ? ` +${s.options} (${s.options} option${s.options > 1 ? 's' : ''})` : ''}
-                {' = '}{plantn}
-              </Typography>
-              <Typography variant="body2" sx={{ mt: 1 }}>
-                Plan time = (rating {rating} + {s.options} options) × multiplier {s.multiplier} = {planHrs} hrs
-              </Typography>
-            </AccordionDetails>
-          </Accordion>
-
-          {/* Bug Test (optional rule) */}
-          <Accordion variant="outlined" sx={{ mb: 2 }}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="subtitle2">Bug Test (Optional Rule)</Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>
-                (Matrix p.81 — open test each time program is used)
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                Every time the program is run, make an Open Test using Computer (Programming).
-                Bugs appear on the n-th use (n = Occurrence factor from rolls). TN modifiers:
-              </Typography>
-              <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Situation</TableCell>
-                      <TableCell align="right">Modifier</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    <TableRow>
-                      <TableCell>Program difficulty (−(Rating+2))</TableCell>
-                      <TableCell align="right">{-(rating + 2)}</TableCell>
-                    </TableRow>
-                    {s.options > 0 && (
-                      <TableRow>
-                        <TableCell>Options (−(options+2))</TableCell>
-                        <TableCell align="right">{-(s.options + 2)}</TableCell>
-                      </TableRow>
-                    )}
-                    {s.teamMembers > 1 && (
-                      <TableRow>
-                        <TableCell>Team ({s.teamMembers} members)</TableCell>
-                        <TableCell align="right">{-(s.teamMembers + 2)}</TableCell>
-                      </TableRow>
-                    )}
-                    {isMainframe && (
-                      <TableRow>
-                        <TableCell>Used mainframe</TableCell>
-                        <TableCell align="right">+2</TableCell>
-                      </TableRow>
-                    )}
-                    {s.reducedTime && (
-                      <TableRow>
-                        <TableCell>Reduced base time</TableCell>
-                        <TableCell align="right">+3</TableCell>
-                      </TableRow>
-                    )}
-                    {lang && lang.id !== 'none' && lang.bugMod !== 0 && (
-                      <TableRow>
-                        <TableCell>{lang.label} (language)</TableCell>
-                        <TableCell align="right">
-                          {lang.id === 'novatech'
-                            ? `${lang.bugMod} × ${s.options} options = ${lang.bugMod * s.options}`
-                            : lang.bugMod}
-                        </TableCell>
-                      </TableRow>
-                    )}
-                    <TableRow sx={{ bgcolor: 'action.hover' }}>
-                      <TableCell><strong>Total Bug TN modifier</strong></TableCell>
-                      <TableCell align="right"><strong>{bugTN >= 0 ? '+' : ''}{bugTN}</strong></TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </TableContainer>
-              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                GM rolls 2D6 ÷ base time (round up) on failure. That number = minimum uses before bugs manifest.
-              </Typography>
-            </AccordionDetails>
-          </Accordion>
-
-        </Grid>
-
-        {/* ── Right column: results ───────────────────────────────────── */}
-        <Grid item xs={12} md={5}>
-          <Box sx={{ position: 'sticky', top: 80 }}>
-
-            {/* Programming Test */}
-            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-              <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Computer (Programming) vs TN {finalTN}
-                {compDice > 0 && ` · +${compDice} comp. dice from suite`}
-              </Typography>
-
-              <Box sx={{ mb: 1 }}>
-                <StatRow label="Base TN (program rating)" value={baseTN} />
-                {s.doubleMem && <StatRow label="Double memory" value="−2" />}
-                {s.planSuccesses > 0 && <StatRow label={`Plan successes (×${s.planSuccesses})`} value={`−${s.planSuccesses}`} />}
-                {host?.mod && <StatRow label={host.label} value={host.mod} />}
-                {lang?.id === 'mct_iconix' && <StatRow label="MCT Iconix 7" value="−1" />}
-                {lang?.id === 'oblong' && <StatRow label="Oblong" value="−2" />}
-              </Box>
-
-              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
-                <Chip color="primary" label={`Final TN: ${finalTN}`} />
-                {compDice > 0 && <Chip color="secondary" label={`+${compDice} comp. dice`} />}
-                {lang?.id === 'machodev' && <Chip color="warning" size="small" label={`Effective rating: ${effectiveRating} (MachoDev −1)`} />}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 2 }}>
+                <Chip color="primary" label={`Actual size: ${fmt(actualSizeMp)} Mp (memory)`} />
+                {designSizeMp != null && designSizeMp !== actualSizeMp && (
+                  <Chip label={`Design size: ${fmt(designSizeMp)} Mp (for time)`} variant="outlined" color="primary" />
+                )}
+                <Chip label={`Base time: ${fmtDays(effectiveBasedays)}`} />
+                {lang?.id === 'renraku' && <Chip color="warning" size="small" label="Renraku Teng ×2 base time" />}
               </Box>
             </Paper>
 
-            {/* Task Period */}
             <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-              <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
-              <Box sx={{ mb: 1 }}>
+              <Typography variant="subtitle2" gutterBottom>Programming Conditions</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+                <Box>
+                  <TextField
+                    label="Program Plan Successes"
+                    type="number" size="small" sx={{ width: 200 }}
+                    value={s.planSuccesses}
+                    onChange={e => set('planSuccesses', Math.max(0, +e.target.value))}
+                    inputProps={{ min: 0 }}
+                  />
+                  <Typography variant="caption" color="text.secondary" display="block">Each success −1 to Programming TN</Typography>
+                </Box>
+                <Box>
+                  <TextField
+                    label="Team Members (total)"
+                    type="number" size="small" sx={{ width: 180 }}
+                    value={s.teamMembers}
+                    onChange={e => set('teamMembers', Math.max(1, +e.target.value))}
+                    inputProps={{ min: 1 }}
+                  />
+                  <Typography variant="caption" color="text.secondary" display="block">1 = solo; &gt;1 = team programming</Typography>
+                </Box>
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Mainframe Host</InputLabel>
+                  <Select value={s.hostColor} label="Mainframe Host" onChange={e => set('hostColor', e.target.value)}>
+                    {HOST_COLORS.map(h => (
+                      <MenuItem key={h.id} value={h.id}>
+                        {h.label}{h.mod != null ? ` (${h.mod > 0 ? '+' : ''}${h.mod} TN)` : ''}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Programming Language</InputLabel>
+                  <Select value={s.language} label="Programming Language" onChange={e => set('language', e.target.value)}>
+                    {ProgrammingLanguages.map(l => (
+                      <MenuItem key={l.id} value={l.id}>
+                        {l.label}{l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+              <Box>
+                <FormControlLabel
+                  control={<Checkbox checked={s.doubleMem} onChange={e => set('doubleMem', e.target.checked)} />}
+                  label={<>Computer has double the required memory <InfoTip text="≥ 2× program size in both active and storage. Grants −2 TN." /></>}
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={s.reducedTime} onChange={e => set('reducedTime', e.target.checked)} />}
+                  label={<>Used optional rule to reduce base time <InfoTip text="Adds +3 to Bug Test TN." /></>}
+                />
+              </Box>
+              {lang && lang.id !== 'none' && lang.otherEffect && (
+                <Alert severity="info" sx={{ mt: 1 }} icon={false}>
+                  <strong>{lang.label}:</strong> {lang.otherEffect}
+                </Alert>
+              )}
+            </Paper>
+
+            <Accordion variant="outlined" sx={{ mb: 2 }}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle2">Program Plan Helper</Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>(Matrix p.78)</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Typography variant="body2" color="text.secondary" gutterBottom>
+                  A program plan reduces the Programming TN by 1 per success. Roll Combat/Operational Utility Design or Cyberterminal Code Design vs TN {plantn}.
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                  <Chip label={`Plan TN: ${plantn}`} color="primary" />
+                  <Chip label={`Plan time: ${fmt(planHrs)} hrs (${(planHrs / 8).toFixed(1)} days)`} />
+                  <Chip label={`Plan size: ${fmt(planMp)} Mp`} />
+                </Box>
+                <Typography variant="caption" color="text.secondary">
+                  TN = 4{rating <= 4 ? ' −1 (rating 1–4)' : rating >= 10 ? ' +1 (rating 10+)' : ''}{optionCount > 0 ? ` +${optionCount} options` : ''} = {plantn}
+                </Typography>
+              </AccordionDetails>
+            </Accordion>
+
+            <Accordion variant="outlined" sx={{ mb: 2 }}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle2">Bug Test (Optional Rule)</Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>(Matrix p.81)</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <TableContainer component={Paper} variant="outlined">
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Situation</TableCell>
+                        <TableCell align="right">Modifier</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <TableRow><TableCell>Program difficulty (−(Rating+2))</TableCell><TableCell align="right">{-(rating + 2)}</TableCell></TableRow>
+                      {optionCount > 0 && <TableRow><TableCell>Options (−(options+2))</TableCell><TableCell align="right">{-(optionCount + 2)}</TableCell></TableRow>}
+                      {s.teamMembers > 1 && <TableRow><TableCell>Team ({s.teamMembers} members)</TableCell><TableCell align="right">{-(s.teamMembers + 2)}</TableCell></TableRow>}
+                      {isMainframe && <TableRow><TableCell>Used mainframe</TableCell><TableCell align="right">+2</TableCell></TableRow>}
+                      {s.reducedTime && <TableRow><TableCell>Reduced base time</TableCell><TableCell align="right">+3</TableCell></TableRow>}
+                      {lang && lang.id !== 'none' && lang.bugMod !== 0 && (
+                        <TableRow>
+                          <TableCell>{lang.label}</TableCell>
+                          <TableCell align="right">{lang.id === 'novatech' ? `${lang.bugMod} × ${optionCount} = ${lang.bugMod * optionCount}` : lang.bugMod}</TableCell>
+                        </TableRow>
+                      )}
+                      <TableRow sx={{ bgcolor: 'action.hover' }}>
+                        <TableCell><strong>Total Bug TN modifier</strong></TableCell>
+                        <TableCell align="right"><strong>{bugTN >= 0 ? '+' : ''}{bugTN}</strong></TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </AccordionDetails>
+            </Accordion>
+          </Grid>
+
+          {/* Right column */}
+          <Grid item xs={12} md={5}>
+            <Box sx={{ position: 'sticky', top: 80 }}>
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  Computer (Programming) vs TN {finalTN}{compDice > 0 ? ` · +${compDice} comp. dice` : ''}
+                </Typography>
+                <Box sx={{ mb: 1 }}>
+                  <StatRow label="Base TN (program rating)" value={baseTN} />
+                  {s.doubleMem && <StatRow label="Double memory" value="−2" />}
+                  {s.planSuccesses > 0 && <StatRow label={`Plan successes (×${s.planSuccesses})`} value={`−${s.planSuccesses}`} />}
+                  {host?.mod && <StatRow label={host.label} value={host.mod} />}
+                  {lang?.id === 'mct_iconix' && <StatRow label="MCT Iconix 7" value="−1" />}
+                  {lang?.id === 'oblong' && <StatRow label="Oblong" value="−2" />}
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+                  <Chip color="primary" label={`Final TN: ${finalTN}`} />
+                  {compDice > 0 && <Chip color="secondary" label={`+${compDice} comp. dice`} />}
+                  {lang?.id === 'machodev' && <Chip color="warning" size="small" label={`Effective rating: ${effectiveRating} (MachoDev −1)`} />}
+                </Box>
+              </Paper>
+
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
                 <TextField
                   label="Successes on Programming Test"
                   type="number" size="small" fullWidth
                   value={s.programmingSuccesses}
                   onChange={e => set('programmingSuccesses', Math.max(1, +e.target.value))}
-                  inputProps={{ min: 1 }}
-                  sx={{ mb: 1 }}
+                  inputProps={{ min: 1 }} sx={{ mb: 1 }}
                 />
-                {s.teamMembers > 1 && (
+                {s.teamMembers > 1 && effectiveTaskDays && (
                   <Alert severity="info" sx={{ mb: 1, py: 0.5 }} icon={false}>
-                    Team: roll dice equal to average Computer (Programming) skill (round down).
-                    Each member works min {fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days.
+                    Team: each member works min {fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days.
                   </Alert>
                 )}
-              </Box>
-              <StatRow label="Base time" value={fmtDays(effectiveBasedays)} />
-              <StatRow label="Programming successes" value={s.programmingSuccesses} />
-              <StatRow
-                label="Task period"
-                value={effectiveTaskDays ? fmtDays(effectiveTaskDays) : '—'}
-                highlight
-                caption={effectiveTaskDays ? `${fmt(effectiveTaskDays * 8)} hrs total work` : undefined}
-              />
-              {s.teamMembers > 1 && effectiveTaskDays && (
-                <StatRow
-                  label={`Min days per member (÷${s.teamMembers + 1})`}
-                  value={`${fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days`}
-                />
-              )}
-            </Paper>
+                <StatRow label="Base time" value={fmtDays(effectiveBasedays)} />
+                <StatRow label="Programming successes" value={s.programmingSuccesses} />
+                <StatRow label="Task period" value={effectiveTaskDays ? fmtDays(effectiveTaskDays) : '—'} highlight
+                  caption={effectiveTaskDays ? `${fmt(effectiveTaskDays * 8)} hrs total work` : undefined} />
+                {s.teamMembers > 1 && effectiveTaskDays && (
+                  <StatRow label={`Min days per member (÷${s.teamMembers + 1})`} value={`${fmt(Math.ceil(effectiveTaskDays / (s.teamMembers + 1)))} days`} />
+                )}
+              </Paper>
 
-            {/* Summary chips */}
-            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-              <Typography variant="subtitle2" gutterBottom>Program Summary</Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                <Chip size="small" color="primary" label={`Rating ${rating}`} />
-                <Chip size="small" label={`×${s.multiplier} multiplier`} />
-                <Chip size="small" label={`${fmt(sizeMp)} Mp`} />
-                <Chip size="small" label={`TN ${finalTN}`} />
-                {compDice > 0 && <Chip size="small" color="secondary" label={`+${compDice} comp dice`} />}
-                {s.options > 0 && <Chip size="small" label={`${s.options} option${s.options > 1 ? 's' : ''}`} />}
-                {s.upgradeMode && <Chip size="small" color="warning" label={`Upgrade from ${s.oldRating}`} />}
-                {lang && lang.id !== 'none' && <Chip size="small" label={lang.label} />}
-                {s.hostColor !== 'none' && <Chip size="small" label={HOST_COLORS.find(h => h.id === s.hostColor)?.label} />}
-              </Box>
-            </Paper>
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Program Summary</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  <Chip size="small" color="primary" label={`Rating ${rating}`} />
+                  <Chip size="small" label={`×${s.multiplier} multiplier`} />
+                  <Chip size="small" label={`${fmt(actualSizeMp)} Mp`} />
+                  <Chip size="small" label={`TN ${finalTN}`} />
+                  {compDice > 0 && <Chip size="small" color="secondary" label={`+${compDice} comp dice`} />}
+                  {optionCount > 0 && <Chip size="small" label={`${optionCount} option${optionCount > 1 ? 's' : ''}`} />}
+                  {s.upgradeMode && <Chip size="small" color="warning" label={`Upgrade from ${s.oldRating}`} />}
+                  {lang && lang.id !== 'none' && <Chip size="small" label={lang.label} />}
+                  {s.hostColor !== 'none' && <Chip size="small" label={HOST_COLORS.find(h => h.id === s.hostColor)?.label} />}
+                </Box>
+              </Paper>
 
-            {/* Quick Reference */}
-            <Accordion variant="outlined">
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="subtitle2">Quick Reference</Typography>
-              </AccordionSummary>
-              <AccordionDetails sx={{ p: 1 }}>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Program Size:</strong> Rating² × Multiplier (Mp)</Typography>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Size in days (1 day = 8 hrs work)</Typography>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Period:</strong> Base time ÷ successes (days)</Typography>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = Computer (Programming) skill{programType.isPersona ? ' × 1.5 (round down) for persona' : ''}</Typography>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Suite:</strong> Rating² × 15 Mp · provides comp. dice (capped by skill)</Typography>
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Memory:</strong> Computer must have program size in both active and storage memory. Double = −2 TN.</Typography>
-                <Divider sx={{ my: 1 }} />
-                <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Programming Suite Table:</strong></Typography>
-                {[1,2,3,4,5,6,7,8,9,10].map(r => (
-                  <Typography key={r} variant="caption" display="block" sx={{ pl: 1 }}>
-                    Rating {r}: {r*r*15} Mp
-                  </Typography>
-                ))}
-              </AccordionDetails>
-            </Accordion>
-
-          </Box>
+              <Accordion variant="outlined">
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2">Quick Reference</Typography>
+                </AccordionSummary>
+                <AccordionDetails sx={{ p: 1 }}>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Program Size:</strong> Rating² × Multiplier (Mp)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Size in days (1 day = 8 hrs)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Period:</strong> Base time ÷ successes</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = skill{programType.isPersona ? ' × 1.5 (round down)' : ''}</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Suite:</strong> Rating² × 15 Mp · comp. dice capped by skill</Typography>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Frame/Agent size multipliers:</strong></Typography>
+                  <Typography variant="caption" display="block" sx={{ pl: 1 }}>Dumb Frame ×3 · Smart Frame ×6 · Agent ×10 · IC Construct ×3</Typography>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Suite Size Table:</strong></Typography>
+                  {[1,2,3,4,5,6,7,8,9,10].map(r => (
+                    <Typography key={r} variant="caption" display="block" sx={{ pl: 1 }}>Rating {r}: {r*r*15} Mp</Typography>
+                  ))}
+                </AccordionDetails>
+              </Accordion>
+            </Box>
+          </Grid>
         </Grid>
-      </Grid>
+      )}
+
+      {subTab === 1 && <FrameAgentCalculator skill={s.skill} compDice={compDice} />}
+      {subTab === 2 && <WormsCalculator skill={s.skill} compDice={compDice} />}
+      {subTab === 3 && <CommandSetsInfo skill={s.skill} />}
     </Box>
   );
 }

--- a/src/data/SR3/Gear.json
+++ b/src/data/SR3/Gear.json
@@ -61440,5 +61440,57 @@
         "BookPage": "sr3.239"
       }
     ]
+  },
+  "Miscellaneous Components": {
+    "Name": "Miscellaneous Components",
+    "attributes": [
+      "Cost",
+      "Availability",
+      "Street Index",
+      "Legal",
+      "BookPage"
+    ],
+    "entries": [
+      { "Name": "Audio Speakers", "Cost": "25-2500", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Battery Pack", "Cost": "25", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Camera — Trideo", "Cost": "200-2000", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Camera — Video", "Cost": "100-1000", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Casing (Rating 3)", "Cost": "100", "Availability": "2/12 hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Casing (Higher Barrier rating)", "Cost": "500 per point", "Availability": "Rating/(12×rating) hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Chip Reader", "Cost": "200", "Availability": "Always", "Street Index": ".75", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Credstick Reader Rating 1", "Cost": "12000", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Credstick Reader Rating 2-3", "Cost": "60000", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Credstick Reader Rating 4-5", "Cost": "100000", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Credstick Reader Rating 6+", "Cost": "Restricted", "Availability": "Restricted", "Street Index": "NA", "Legal": "Restricted", "BookPage": "sr3.302" },
+      { "Name": "Credstick Slot", "Cost": "50", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Disk Drive", "Cost": "200", "Availability": "Always", "Street Index": ".75", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Display Screen", "Cost": "100", "Availability": "2/24 hrs", "Street Index": "2", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Fiberoptic Cable (per meter)", "Cost": "1", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Hitcher Jack", "Cost": "250", "Availability": "2/48 hrs", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Keyboard", "Cost": "50", "Availability": "Always", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Microphone (basic)", "Cost": "50", "Availability": "Always", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Microwave Dish — Standard Portable", "Cost": "5000", "Availability": "6/1 wk", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Microwave Dish — Large Portable", "Cost": "10000", "Availability": "8/2 wks", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Microwave Dish — Fixed Base", "Cost": "2500", "Availability": "8/1 mo", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Monitor", "Cost": "100-25000", "Availability": "2/12 hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Off-Line Storage (per Mp)", "Cost": "50+(5×Mp)", "Availability": "2/24 hrs", "Street Index": "2", "Legal": "9P-V", "BookPage": "sr3.302" },
+      { "Name": "Passkey Reader (Blank)", "Cost": "250", "Availability": "2/24 hrs", "Street Index": "2", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Power Cord", "Cost": "15", "Availability": "4/48 hrs", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Printer", "Cost": "100", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Scanner — Finger/Thumbprint (per Rating)", "Cost": "Rating×200", "Availability": "Rating/72 hrs", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Scanner — Palmprint (per Rating)", "Cost": "Rating×300", "Availability": "(Rating+1)/72 hrs", "Street Index": "2", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Scanner — Retinal (per Rating)", "Cost": "Rating×1000", "Availability": "(Rating+1)/72 hrs", "Street Index": "2", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Scanner — Text/Picture", "Cost": "100", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Signal Locator — Simlink (per Rating)", "Cost": "25000+(Rating×5000)", "Availability": "8/2 wks", "Street Index": "2", "Legal": "8P-L", "BookPage": "sr3.302" },
+      { "Name": "Temp. Satellite Dish — Electronics", "Cost": "1000", "Availability": "4/24 hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Temp. Satellite Dish — Plastic Webbing", "Cost": "5", "Availability": "4/24 hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Temp. Satellite Dish — Spray Polymer (1 use)", "Cost": "1", "Availability": "4/24 hrs", "Street Index": ".5", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Touchpad", "Cost": "50", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Touchpad w/Mouse Adapter", "Cost": "60", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Touchpad w/Trackball Adapter", "Cost": "60", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Trode Jack", "Cost": "500", "Availability": "Always", "Street Index": "NA", "Legal": "Legal", "BookPage": "sr3.302" },
+      { "Name": "Vid-link Transmitter (per Rating)", "Cost": "Rating×2000", "Availability": "4/1 wk", "Street Index": "2", "Legal": "8P-L", "BookPage": "sr3.302" },
+      { "Name": "VR Kit", "Cost": "250", "Availability": "Always", "Street Index": "1", "Legal": "Legal", "BookPage": "sr3.302" }
+    ]
   }
 }

--- a/src/data/SR3/ProgrammingRules.js
+++ b/src/data/SR3/ProgrammingRules.js
@@ -1,5 +1,5 @@
 // SR3 Matrix Programming Rules
-// Source: Matrix (SR3 supplement), pp. 76–81
+// Source: Matrix (SR3 supplement), pp. 76–86
 
 // ── Program Size ──────────────────────────────────────────────────────────────
 // Size (Mp) = Rating² × Multiplier
@@ -120,6 +120,403 @@ export function bugTestTN(programRating, programSkill, options, teamMembers, use
   }
   return tn;
 }
+
+// ── Program Options (Matrix pp. 82–86) ───────────────────────────────────────
+// IMPORTANT: Option design rating modifiers do NOT change the Programming TN.
+// TN = base program rating (unmodified). Options only affect:
+//   - Design rating → design size → programming time
+//   - Actual size (only for One-Shot, Optimization, Squeeze, Sensitive)
+//
+// designRatingMod: flat modifier to design rating
+// designRatingModPerPoint: per point of option rating (for rated options like stealth, area)
+// hasOptionRating: true if option has its own rating (stealth-4, area-3, etc.)
+// actualSizeMult: multiplier applied to actual size (default 1.0)
+// designSizeMult: multiplier applied to design size AFTER rating-based calc (default 1.0)
+// availableFor: 'utility' | 'ic' | 'both'
+
+export const ProgramOptions = [
+  // ── Utility Options ──────────────────────────────────────────────────────
+  {
+    id: 'adaptive',
+    label: 'Adaptive',
+    availableFor: 'utility',
+    designRatingMod: 2,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Utility can run at any rating up to its base rating. Common for utilities used on variable cyberterminals.',
+  },
+  {
+    id: 'area',
+    label: 'Area',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    designRatingModPerPoint: 1,
+    hasOptionRating: true,
+    optionRatingLabel: 'Area Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Engages multiple targets in the same system (all targets must be in the same system). TN +2 per target beyond the area option rating. Armor utility protects against area rating.',
+  },
+  {
+    id: 'bug_ridden',
+    label: 'Bug-Ridden (Optional)',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Only used with optional bug rules. Bug-ridden utility has a relatively frequent bug Occurrence factor — subtract the bug-ridden rating from 12.',
+  },
+  {
+    id: 'chaser',
+    label: 'Chaser',
+    availableFor: 'utility',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Negates the +2 TN penalty for attacks against IC with the Shift option. Adds an additional +2 TN penalty to attacks against IC with the Shield option. Cannot be combined with Penetration.',
+  },
+  {
+    id: 'crashguard',
+    label: 'Crashguard',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    designRatingModPerPoint: 1,
+    hasOptionRating: true,
+    optionRatingLabel: 'Crashguard Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Makes utility more resistant to crash attempts. Apply −1 modifier to Opposed Test for each point of Crashguard rating when tar baby/tar pit IC attacks. Only works in active memory.',
+  },
+  {
+    id: 'dinab',
+    label: 'DINAB',
+    availableFor: 'utility',
+    designRatingMod: 2,
+    designRatingModPerPoint: 1,
+    hasOptionRating: true,
+    optionRatingLabel: 'DINAB Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Gives the utility a built-in Computer skill equal to the DINAB rating. User spends a Free Action to activate; utility then runs itself. DINAB loses 1 rating point every time it fails a test.',
+  },
+  {
+    id: 'limit',
+    label: 'Limit',
+    availableFor: 'utility',
+    designRatingMod: -1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Restricts utility to a single type of target (personas, IC programs, frames, or SKs). Useless against any other target type.',
+  },
+  {
+    id: 'noise',
+    label: 'Noise',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    designRatingModPerPoint: -1,
+    hasOptionRating: true,
+    optionRatingLabel: 'Noise Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: "Operational utility; doesn't use direct brute-force measures. Character's Detection Factor is lowered by the noise rating for System Tests in which this utility is used.",
+  },
+  {
+    id: 'one_shot',
+    label: 'One-Shot',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    hasOptionRating: false,
+    actualSizeMult: 0.25,   // reduces actual size by 75%
+    designSizeMult: 1.5,    // increases design size by 50%
+    notes: 'Single-use: after execution it vanishes. Must be reloaded with Swap Memory. Reduces ACTUAL size by 75%; increases DESIGN size by 50%. Tar baby/tar pit wipes out ALL copies in active memory.',
+  },
+  {
+    id: 'optimization',
+    label: 'Optimization',
+    availableFor: 'both',
+    designRatingMod: 0,
+    hasOptionRating: false,
+    actualSizeMult: 0.5,   // reduces actual size by 50%
+    designSizeMult: 2.0,   // increases design size by 100%
+    notes: 'Reduces ACTUAL size by 50%; increases DESIGN size by 100%.',
+  },
+  {
+    id: 'penetration',
+    label: 'Penetration',
+    availableFor: 'utility',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Defeats the Shield IC option — utility does not receive the +2 TN modifier against IC programs with Shield. Against IC with Shift, must add +4 to TN. Cannot be combined with Chaser.',
+  },
+  {
+    id: 'selective',
+    label: 'Selective',
+    availableFor: 'utility',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: "When used against a target icon, checks if the icon uses a special passkey. If the icon bears the passkey, the program won't work against that icon and targets it as normal.",
+  },
+  {
+    id: 'sensitive',
+    label: 'Sensitive',
+    availableFor: 'both',
+    designRatingMod: 0,
+    hasOptionRating: false,
+    actualSizeMult: 0.5,   // reduces both actual and design size by 50%
+    designSizeMult: 0.5,
+    notes: 'Makes program effective only on systems of a particular type (manufacturer, language, or iconography). For Programming Test: use average of Computer (Programming) skill and relevant Knowledge skill. Reduces BOTH actual and design size by 50%.',
+  },
+  {
+    id: 'sneak',
+    label: 'Sneak',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    designRatingModPerPoint: 2,
+    hasOptionRating: true,
+    optionRatingLabel: 'Sneak Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Each point of Sneak rating adds +1 to the user\'s Detection Factor when making a System Test with this utility.',
+  },
+  {
+    id: 'squeeze',
+    label: 'Squeeze',
+    availableFor: 'utility',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 0.5,   // reduces actual size by 50% (for uploading purposes)
+    designSizeMult: 1,
+    notes: 'Self-compressed program. Actual size reduced by 50% for upload/storage. Cannot be used until decompressed (Complex Action). If also Optimized, must decompress twice. Design size modifier affects design size only.',
+  },
+  {
+    id: 'stealth',
+    label: 'Stealth',
+    availableFor: 'utility',
+    designRatingMod: 0,
+    designRatingModPerPoint: 1,
+    hasOptionRating: true,
+    optionRatingLabel: 'Stealth Rating',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Reduces security tally additions caused by crashing IC programs. When a decker uses this utility to crash an IC, reduce the resulting security tally increase by the stealth rating.',
+  },
+  {
+    id: 'targeting',
+    label: 'Targeting',
+    availableFor: 'utility',
+    designRatingMod: 2,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Offensive utility zeros in on target weaknesses. Gives a −2 TN modifier for attacks in cybercombat.',
+  },
+
+  // ── IC Options ───────────────────────────────────────────────────────────
+  {
+    id: 'ic_armor',
+    label: 'Armor',
+    availableFor: 'ic',
+    designRatingMod: 2,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Reduces the Power of any attack against the IC by 2. If attacked by a utility with the Area option, armor rating is increased by 2.',
+  },
+  {
+    id: 'ic_cascading',
+    label: 'Cascading IC',
+    availableFor: 'ic',
+    designRatingMod: 3,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Each missed attack or failed damage increases Security Value by 1 and Attack Test value by 1 (cumulative). Resets when IC defeats a target. Maximum increase by host color: Blue=1, Green=25%/2, Orange=50%/3, Red=100%/4.',
+  },
+  {
+    id: 'ic_expert_defense',
+    label: 'Expert Defense',
+    availableFor: 'ic',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Each point adds 1 die to Damage Resistance Tests but removes 1 die from Attack Tests. Maximum Expert Defense rating: 3. Incompatible with Expert Offense.',
+  },
+  {
+    id: 'ic_expert_offense',
+    label: 'Expert Offense',
+    availableFor: 'ic',
+    designRatingMod: 1,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: "Each point adds 1 die to the IC's Security Value for Attack Tests but removes 1 die from Damage Resistance Tests. Maximum Expert Offense rating: 3. Incompatible with Expert Defense.",
+  },
+  {
+    id: 'ic_party_cluster',
+    label: 'Party Cluster',
+    availableFor: 'ic',
+    designRatingMod: 3,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'IC coordinates with similar IC pieces attacking in tandem. Activated together on the same trigger. Total ratings of party IC in a cluster cannot exceed Security Value × 2.',
+  },
+  {
+    id: 'ic_shield',
+    label: 'Shield',
+    availableFor: 'ic',
+    designRatingMod: 2,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Adds +2 TN modifier to all tests to hit the protected IC in cybercombat. Extra-effective with Chaser (automatic, no penalty). With Shift, attacking utility must add +4 TN instead of +2.',
+  },
+  {
+    id: 'ic_shift',
+    label: 'Shift',
+    availableFor: 'ic',
+    designRatingMod: 2,
+    hasOptionRating: false,
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Constantly relocates memory space and system addresses. Adds +2 TN modifier to all tests to hit the IC. Defeated automatically by Chaser. With Penetration, must add +4 TN instead of +2.',
+  },
+  {
+    id: 'ic_trap',
+    label: 'Trap',
+    availableFor: 'ic',
+    designRatingMod: 0,
+    designRatingModPerPoint: 1,
+    hasOptionRating: true,
+    optionRatingLabel: 'Number of linked IC programs',
+    actualSizeMult: 1,
+    designSizeMult: 1,
+    notes: 'Triggers one or more other pieces of IC (usually gray or black IC) when this IC is destroyed in cybercombat.',
+  },
+];
+
+// ── Design Size / Actual Size with Options ────────────────────────────────────
+// Design size = design_rating² × multiplier × designSizeMult modifiers
+// Actual size = base_rating² × multiplier × actualSizeMult modifiers
+// TN for programming = base program rating (NOT affected by options)
+
+export function calcDesignRating(baseRating, selectedOptions) {
+  // selectedOptions: Array of { id, optionRating }
+  let dr = baseRating;
+  for (const sel of selectedOptions) {
+    const opt = ProgramOptions.find(o => o.id === sel.id);
+    if (!opt) continue;
+    dr += (opt.designRatingMod ?? 0);
+    if (opt.designRatingModPerPoint && sel.optionRating > 0) {
+      dr += opt.designRatingModPerPoint * sel.optionRating;
+    }
+  }
+  return Math.max(1, dr);
+}
+
+export function calcDesignSize(baseRating, multiplier, selectedOptions) {
+  const dr = calcDesignRating(baseRating, selectedOptions);
+  let size = dr * dr * multiplier;
+  for (const sel of selectedOptions) {
+    const opt = ProgramOptions.find(o => o.id === sel.id);
+    if (!opt) continue;
+    if (opt.designSizeMult && opt.designSizeMult !== 1) size *= opt.designSizeMult;
+  }
+  return Math.round(size);
+}
+
+export function calcActualSize(baseRating, multiplier, selectedOptions) {
+  let size = baseRating * baseRating * multiplier;
+  for (const sel of selectedOptions) {
+    const opt = ProgramOptions.find(o => o.id === sel.id);
+    if (!opt) continue;
+    if (opt.actualSizeMult && opt.actualSizeMult !== 1) size *= opt.actualSizeMult;
+  }
+  return Math.round(size);
+}
+
+// ── IC Program Size Multipliers (Matrix IC Size Multipliers Table) ────────────
+export const ICPrograms = [
+  { id: 'black_cerebropathic', label: 'Black — Cerebropathic', sizeMult: 16 },
+  { id: 'black_lethal',        label: 'Black — Lethal',        sizeMult: 25 },
+  { id: 'black_nonlethal',     label: 'Black — Non-lethal',    sizeMult: 12 },
+  { id: 'black_psychotropic',  label: 'Black — Psychotropic',  sizeMult: 20 },
+  { id: 'blaster',             label: 'Blaster',               sizeMult: 10 },
+  { id: 'crippler',            label: 'Crippler',              sizeMult:  6 },
+  { id: 'data_bomb',           label: 'Data Bomb',             sizeMult:  5 },
+  { id: 'killer',              label: 'Killer',                sizeMult:  8 },
+  { id: 'pavlov',              label: 'Pavlov',                sizeMult:  4 },
+  { id: 'probe',               label: 'Probe',                 sizeMult:  3 },
+  { id: 'ripper',              label: 'Ripper',                sizeMult:  8 },
+  { id: 'scout',               label: 'Scout',                 sizeMult:  5 },
+  { id: 'scramble',            label: 'Scramble',              sizeMult:  3 },
+  { id: 'sparky',              label: 'Sparky',                sizeMult: 12 },
+  { id: 'tar_baby',            label: 'Tar Baby',              sizeMult:  5 },
+  { id: 'tar_pit',             label: 'Tar Pit',               sizeMult:  7 },
+  { id: 'trace',               label: 'Trace',                 sizeMult: 10 },
+];
+
+// ── Frames & Agents (Matrix pp. 88–91) ────────────────────────────────────────
+export const FrameAgentTypes = [
+  {
+    id: 'dumb', label: 'Dumb Frame', sizeMult: 3,
+    personaPointsMult: 1, framePointsMult: 2,
+    hasPilot: false, maxInitBonusDice: 0, hasPersona: true, isIC: false,
+    notes: 'Max rating = Computer×2. No Pilot rating or Initiative bonus dice. Persona Points = core rating.',
+  },
+  {
+    id: 'smart', label: 'Smart Frame', sizeMult: 6,
+    personaPointsMult: 1, framePointsMult: 4,
+    hasPilot: true, maxInitBonusDice: 4, hasPersona: true, isIC: false,
+    notes: 'Max rating = Computer×1.5 (round down). Pilot rating and up to 4D6 Initiative bonus allowed. Persona Points = core rating.',
+  },
+  {
+    id: 'agent', label: 'Agent', sizeMult: 10,
+    personaPointsMult: 2, framePointsMult: 6,
+    hasPilot: true, maxInitBonusDice: 5, hasPersona: true, isIC: false,
+    notes: 'Max rating = Computer (Programming) skill. Persona Points = core rating × 2. Up to 5D6 Initiative bonus.',
+  },
+  {
+    id: 'ic_construct', label: 'IC Construct', sizeMult: 3,
+    personaPointsMult: 0, framePointsMult: 0,
+    hasPilot: false, maxInitBonusDice: 0, hasPersona: false, isIC: true,
+    notes: 'Max rating = Computer×2. No persona attributes, pilot rating, or frame points. IC Payload = rating×2. Hacking Pool = host Security Code.',
+  },
+];
+
+export function maxFrameRating(skill, typeId) {
+  if (typeId === 'smart') return Math.floor(skill * 1.5);
+  if (typeId === 'agent') return skill;
+  return skill * 2;
+}
+export function framePersonaPoints(rating, typeId) {
+  const t = FrameAgentTypes.find(f => f.id === typeId);
+  return t ? rating * t.personaPointsMult : 0;
+}
+export function frameFramePoints(rating, typeId) {
+  const t = FrameAgentTypes.find(f => f.id === typeId);
+  return t ? rating * t.framePointsMult : 0;
+}
+
+// ── Worm Types (Matrix pp. 92–93) ─────────────────────────────────────────────
+// Only Optimization and Selective options allowed for worms.
+export const WormTypes = [
+  { id: 'crashworm', label: 'Crashworm', sizeMult: 2, notes: 'Causes utilities to error on activation; infected utility rolls on Glitch Table.' },
+  { id: 'dataworm',  label: 'Dataworm',  sizeMult: 3, notes: 'Logs all cyberterminal activity and transmits a report to the originator.' },
+  { id: 'deathworm', label: 'Deathworm', sizeMult: 2, notes: 'All persona tests suffer +TN = deathworm rating ÷ 2 (round down).' },
+  { id: 'spawnworm', label: 'Spawnworm', sizeMult: 2, notes: 'Drains active memory; reduces highest-rated active utility by 1 rating per success each Combat Turn.' },
+  { id: 'ringworm',  label: 'Ringworm',  sizeMult: 2, notes: 'Alters cyberterminal icon coding (minor flickering to drastic icon replacement).' },
+  { id: 'tapeworm',  label: 'Tapeworm',  sizeMult: 2, notes: 'Corrupts downloaded files immediately and renders them irretrievable.' },
+];
 
 // ── Upgrading ─────────────────────────────────────────────────────────────────
 // Base upgrade time = time to write from scratch, minus current version base time

--- a/src/data/SR3/ProgrammingRules.js
+++ b/src/data/SR3/ProgrammingRules.js
@@ -1,0 +1,135 @@
+// SR3 Matrix Programming Rules
+// Source: Matrix (SR3 supplement), pp. 76–81
+
+// ── Program Size ──────────────────────────────────────────────────────────────
+// Size (Mp) = Rating² × Multiplier
+export function programSize(rating, multiplier) {
+  return rating * rating * multiplier;
+}
+
+// ── Max Program Rating ────────────────────────────────────────────────────────
+// Cannot exceed Computer (Programming) skill.
+// Persona programs: may not exceed skill × 1.5 (round down).
+export function maxProgramRating(skill, isPersona = false) {
+  if (isPersona) return Math.floor(skill * 1.5);
+  return skill;
+}
+
+// ── Programming Suite Size Table (p.79) ──────────────────────────────────────
+// Suite size = Rating² × 15
+export function suiteSizeMp(rating) {
+  return rating * rating * 15;
+}
+
+// Max complementary dice from suite = suite rating, capped by Computer (Programming) skill
+export function suiteCompDice(suiteRating, skill) {
+  return Math.min(suiteRating, skill);
+}
+
+// ── Base Programming Time ─────────────────────────────────────────────────────
+// Base time (days) = program size (Mp)
+// Each programming day = 8 hours of work
+export function baseTimeDays(sizeMp) { return sizeMp; }
+export function baseTimeHours(sizeMp) { return sizeMp * 8; }
+
+// ── Task Period ───────────────────────────────────────────────────────────────
+// Task period (days) = base time ÷ successes on Computer (Programming) Test
+// Round: standard SR rounding (use ceiling for safety)
+export function taskPeriodDays(basedays, successes) {
+  if (!successes || successes < 1) return null;
+  return Math.ceil(basedays / successes);
+}
+export function taskPeriodHours(days) { return days * 8; }
+
+// ── Programming TN Modifiers (Matrix p.79) ───────────────────────────────────
+// Base TN = unmodified program rating (do not apply option cost modifiers)
+// Then apply modifiers below.
+
+export const ProgrammingModifiers = [
+  { id: 'doubleMem',   label: 'Computer has double the required memory',   mod: -2 },
+  { id: 'noPlan',      label: 'No program plan prepared',                  mod: +2 },
+  { id: 'mainBlue',    label: 'Mainframe — Blue host',                     mod: -1 },
+  { id: 'mainGreen',   label: 'Mainframe — Green host',                    mod: -2 },
+  { id: 'mainOrange',  label: 'Mainframe — Orange host',                   mod: -3 },
+  { id: 'mainRed',     label: 'Mainframe — Red host',                      mod: -4 },
+];
+
+// Program plan successes each subtract 1 from TN (not listed in table but stated in text)
+// Plan success modifier: -1 per success
+
+// ── Program Plan ──────────────────────────────────────────────────────────────
+// Plan creation time (hours) = (rating + options) × multiplier
+// Plan size (Mp) = program size + 10
+// Plan TN = 4 + plan modifiers
+
+export function planTimeHours(rating, options, multiplier) {
+  return (rating + options) * multiplier;
+}
+export function planSizeMp(programSizeMp) {
+  return programSizeMp + 10;
+}
+
+export const PlanModifiers = [
+  { range: '1–4',  label: 'Program rating 1–4',  mod: -1 },
+  { range: '5–9',  label: 'Program rating 5–9',  mod:  0 },
+  { range: '10+',  label: 'Program rating 10+',  mod: +1 },
+];
+// Each option adds +1 to plan TN
+export function planTN(rating, options) {
+  let base = 4;
+  if (rating <= 4)      base += -1;
+  else if (rating >= 10) base += +1;
+  base += options; // +1 per option
+  return base;
+}
+
+// ── Programming Languages (optional rule, Matrix p.81) ────────────────────────
+export const ProgrammingLanguages = [
+  { id: 'none',        label: 'None (default)',     bugMod: 0,   otherEffect: null },
+  { id: 'hololisp',   label: 'HoloLISP',            bugMod: 0,   otherEffect: null },
+  { id: 'machodev',   label: 'MachoDev',            bugMod: +4,  otherEffect: '−1 to program\'s effective rating' },
+  { id: 'mct_iconix', label: 'MCT Iconix 7',        bugMod: +2,  otherEffect: '−1 to Computer (Programming) Test TN' },
+  { id: 'metacomm',   label: 'Metacomm',            bugMod: 0,   otherEffect: null },
+  { id: 'novatech',   label: 'Novatech VRDrive 3',  bugMod: -1,  bugModNote: '−1 per option', otherEffect: null },
+  { id: 'oblong',     label: 'Oblong',              bugMod: -3,  otherEffect: '−2 to Computer (Programming) Test TN' },
+  { id: 'renraku',    label: 'Renraku Teng',        bugMod: -5,  otherEffect: 'Base time ×2' },
+];
+
+// ── Bug Test (optional rule, Matrix p.81) ────────────────────────────────────
+// Open Test using Computer (Programming); bugs appear on every occurrence (n-th use)
+// TN modifiers stacked on top of base skill open test
+
+export function bugTestTN(programRating, programSkill, options, teamMembers, usedMainframe, reducedTime, languageId) {
+  let tn = 0;
+  // Program difficulty: −(Rating + 2, round up) — already rounded since integer
+  tn -= (programRating + 2);
+  // Less than half skill: no additional modifier listed (threshold check for GM)
+  // Options: −(options + 2, round up)
+  if (options > 0) tn -= (options + 2);
+  // Team programming: −(members + 2, round up)
+  if (teamMembers > 1) tn -= (teamMembers + 2);
+  // Used mainframe: +2
+  if (usedMainframe) tn += 2;
+  // Reduced base time: +3
+  if (reducedTime) tn += 3;
+  // Language modifier
+  const lang = ProgrammingLanguages.find(l => l.id === languageId);
+  if (lang && lang.bugMod) {
+    if (lang.id === 'novatech') tn += lang.bugMod * options; // -1 per option
+    else tn += lang.bugMod;
+  }
+  return tn;
+}
+
+// ── Upgrading ─────────────────────────────────────────────────────────────────
+// Base upgrade time = time to write from scratch, minus current version base time
+// Minimum upgrade time = 25% of time to write from scratch
+// New size = new rating² × multiplier (option adds to size as well)
+export function upgradeBaseTimeDays(newRating, multiplier, oldRating) {
+  const newSize  = programSize(newRating, multiplier);
+  const oldSize  = programSize(oldRating, multiplier);
+  const scratch  = baseTimeDays(newSize);
+  const current  = baseTimeDays(oldSize);
+  const minimum  = Math.ceil(scratch * 0.25);
+  return Math.max(scratch - current, minimum);
+}

--- a/src/data/SR3/ProgrammingRules.js
+++ b/src/data/SR3/ProgrammingRules.js
@@ -85,14 +85,14 @@ export function planTN(rating, options) {
 
 // ── Programming Languages (optional rule, Matrix p.81) ────────────────────────
 export const ProgrammingLanguages = [
-  { id: 'none',        label: 'None (default)',     bugMod: 0,   otherEffect: null },
-  { id: 'hololisp',   label: 'HoloLISP',            bugMod: 0,   otherEffect: null },
-  { id: 'machodev',   label: 'MachoDev',            bugMod: +4,  otherEffect: '−1 to program\'s effective rating' },
-  { id: 'mct_iconix', label: 'MCT Iconix 7',        bugMod: +2,  otherEffect: '−1 to Computer (Programming) Test TN' },
-  { id: 'metacomm',   label: 'Metacomm',            bugMod: 0,   otherEffect: null },
-  { id: 'novatech',   label: 'Novatech VRDrive 3',  bugMod: -1,  bugModNote: '−1 per option', otherEffect: null },
-  { id: 'oblong',     label: 'Oblong',              bugMod: -3,  otherEffect: '−2 to Computer (Programming) Test TN' },
-  { id: 'renraku',    label: 'Renraku Teng',        bugMod: -5,  otherEffect: 'Base time ×2' },
+  { id: 'none',        label: 'None (default)',     bugMod: 0,   otherEffect: null,                                          description: null },
+  { id: 'hololisp',   label: 'HoloLISP',            bugMod: 0,   otherEffect: null,                                          description: 'No mechanical effects.' },
+  { id: 'machodev',   label: 'MachoDev',            bugMod: +4,  otherEffect: '−1 to program\'s effective rating',           description: 'Bug TN +4 · Effective program rating −1' },
+  { id: 'mct_iconix', label: 'MCT Iconix 7',        bugMod: +2,  otherEffect: '−1 to Computer (Programming) Test TN',       description: 'Bug TN +2 · Programming TN −1' },
+  { id: 'metacomm',   label: 'Metacomm',            bugMod: 0,   otherEffect: null,                                          description: 'No mechanical effects.' },
+  { id: 'novatech',   label: 'Novatech VRDrive 3',  bugMod: -1,  bugModNote: '−1 per option', otherEffect: null,             description: 'Bug TN −1 per program option' },
+  { id: 'oblong',     label: 'Oblong',              bugMod: -3,  otherEffect: '−2 to Computer (Programming) Test TN',       description: 'Bug TN −3 · Programming TN −2' },
+  { id: 'renraku',    label: 'Renraku Teng',        bugMod: -5,  otherEffect: 'Base time ×2',                               description: 'Bug TN −5 · Base programming time ×2' },
 ];
 
 // ── Bug Test (optional rule, Matrix p.81) ────────────────────────────────────


### PR DESCRIPTION
## Summary
- New **Programming Calculator** optional tab for SR3 decker characters
- Implements all rules from *Matrix* pp. 76–81
- Enabled via Identity tab → "Programming Calculator Tab" checkbox

## What's calculated
- **Program size**: Rating² × Multiplier (Mp)
- **Base programming time**: size in days (8 hrs/day)
- **Task period**: base time ÷ Programming Test successes
- **TN**: program rating ± plan successes, memory bonus, mainframe host, language modifiers
- **Programming Suite**: size (Rating² × 15 Mp) and complementary dice (capped by skill)
- **Upgrade mode**: reduced base time for upgrading existing programs
- **Team programming**: average skill, minimum days per member shown
- **Program Plan Helper** accordion: plan TN, creation hours, plan Mp
- **Bug Test accordion** (optional rule): full modifier table with language effects
- **7 programming languages** with TN and side-effect display

## Test plan
- [ ] Enable Programming Calculator Tab on an SR3 character
- [ ] Verify: Rating 4 × Multiplier 3 = 48 Mp, TN 4, 3 successes → 16 days
- [ ] Verify: double memory checkbox applies −2 TN
- [ ] Verify: plan successes reduce TN by −1 each
- [ ] Verify: Renraku Teng doubles base time
- [ ] Verify: upgrade mode shows reduced time vs writing from scratch
- [ ] Verify: programming suite shows comp. dice capped at skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)