### PR TITLE
SR2 Programming Calculator — Frames, Command Sets, Upgrade Mode, Program Prices

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -23,6 +23,7 @@ import VehicleDesigner from "./VehicleDesigner";
 import WeaponDesigner from "./WeaponDesigner";
 import CyberdeckDesigner from "./CyberdeckDesigner";
 import ProgrammingCalculator from "./ProgrammingCalculator";
+import SR2ProgrammingCalculator from "./SR2ProgrammingCalculator";
 import ContactsPanel from "./ContactsPanel";
 import SheetDisplay from "./SheetDisplay";
 import KarmaDisplay from "./KarmaDisplay";
@@ -1095,7 +1096,7 @@ export default function BasicTabs() {
           />
         </CustomTabPanel>
         <CustomTabPanel value={value} index={16}>
-          <ProgrammingCalculator />
+          {Edition === 'SR2' ? <SR2ProgrammingCalculator /> : <ProgrammingCalculator />}
         </CustomTabPanel>
       </Box>
     </div>

--- a/src/components/SR2ProgrammingCalculator.js
+++ b/src/components/SR2ProgrammingCalculator.js
@@ -1,0 +1,441 @@
+import React, { useState } from 'react';
+import {
+  Box, Typography, Paper, Chip, Alert,
+  FormControl, InputLabel, Select, MenuItem,
+  TextField, Tooltip, Grid, Table, TableBody,
+  TableCell, TableContainer, TableHead, TableRow,
+  Accordion, AccordionSummary, AccordionDetails, Tabs, Tab,
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  SR2Utilities, SR2UtilityOptions, SR2ProgrammingTools,
+  sr2ProgramSize, sr2MaxRating, sr2BaseTimeDays, sr2TaskPeriod,
+  sr2CalcEffectiveRating, sr2CalcActualSize, sr2CalcDesignSize,
+  sr2MaxTeamSize, sr2MaxTeamRating,
+} from '../data/SR2/ProgrammingRules';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function fmt(n) {
+  if (n == null) return '—';
+  return Math.round(n).toLocaleString();
+}
+function fmtDays(days) {
+  if (!days) return '—';
+  if (days === 1) return '1 day (8 hrs)';
+  return `${fmt(days)} days (${fmt(days * 8)} hrs)`;
+}
+function InfoTip({ text }) {
+  return (
+    <Tooltip title={text} placement="right">
+      <InfoOutlinedIcon fontSize="small" sx={{ color: 'text.secondary', cursor: 'help', ml: 0.5, verticalAlign: 'middle' }} />
+    </Tooltip>
+  );
+}
+function StatRow({ label, value, highlight, caption }) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+      <Typography variant="body2" color="text.secondary">{label}</Typography>
+      <Box sx={{ textAlign: 'right' }}>
+        <Typography variant="body2" fontWeight={highlight ? 'bold' : 'normal'} color={highlight ? 'primary.main' : 'text.primary'}>{value}</Typography>
+        {caption && <Typography variant="caption" color="text.secondary" display="block">{caption}</Typography>}
+      </Box>
+    </Box>
+  );
+}
+
+const TYPE_COLORS = {
+  operational: 'info',
+  defensive:   'success',
+  offensive:   'error',
+  special:     'warning',
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+const defaultState = {
+  skill: 6,
+  utilityId: 'analyze',
+  rating: 4,
+  selectedOptions: [],   // [{ id, areaRating?, dinabRating?, skulkRating? }]
+  toolId: 'personal_computer',
+  teamMembers: 1,
+  successes: 2,
+};
+
+export default function SR2ProgrammingCalculator() {
+  const [s, setS] = useState(defaultState);
+  const [subTab, setSubTab] = useState(0);
+  const set = (k, v) => setS(d => ({ ...d, [k]: v }));
+
+  const utility = SR2Utilities.find(u => u.id === s.utilityId) ?? SR2Utilities[0];
+  const tool    = SR2ProgrammingTools.find(t => t.id === s.toolId) ?? SR2ProgrammingTools[0];
+
+  const maxRating      = sr2MaxRating(s.skill, false);
+  const rating         = Math.min(s.rating, maxRating);
+  const effectiveRating = sr2CalcEffectiveRating(rating, s.selectedOptions);
+  const actualSizeMp   = sr2CalcActualSize(rating, utility.mult, s.selectedOptions);
+  const designSizeMp   = sr2CalcDesignSize(rating, utility.mult, s.selectedOptions);
+  const baseSize       = sr2ProgramSize(rating, utility.mult);
+  const baseTimeDays   = sr2BaseTimeDays(designSizeMp);
+  const taskPeriod     = sr2TaskPeriod(baseTimeDays, s.successes);
+  const tn             = rating; // TN = program rating
+
+  const availOpts = SR2UtilityOptions.filter(o => utility.availableOptions.includes(o.id));
+
+  function toggleOption(id) {
+    setS(d => {
+      const has = d.selectedOptions.find(o => o.id === id);
+      return has
+        ? { ...d, selectedOptions: d.selectedOptions.filter(o => o.id !== id) }
+        : { ...d, selectedOptions: [...d.selectedOptions, { id }] };
+    });
+  }
+  function setOptSubRating(id, key, val) {
+    setS(d => ({
+      ...d,
+      selectedOptions: d.selectedOptions.map(o => o.id === id ? { ...o, [key]: val } : o),
+    }));
+  }
+
+  const selOpts = s.selectedOptions;
+
+  return (
+    <Box sx={{ p: 2, maxWidth: 1100 }}>
+      <Typography variant="h5" gutterBottom>
+        Programming Calculator
+        <Chip label="SR2 / VR2 Rules" size="small" variant="outlined" sx={{ ml: 1, fontSize: '0.7rem' }} color="secondary" />
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Calculate programming time, TNs and task periods for SR2 deckers. Source: <em>Virtual Realities 2.0</em> pp. 101–104, 161.
+      </Typography>
+
+      {/* Shared character section */}
+      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Typography variant="subtitle2" gutterBottom>Character</Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          <TextField
+            label="Computer Skill"
+            type="number" size="small" sx={{ width: 180 }}
+            value={s.skill}
+            onChange={e => set('skill', Math.max(1, Math.min(12, +e.target.value)))}
+            inputProps={{ min: 1, max: 12 }}
+            helperText={`Max utility rating: ${maxRating}`}
+          />
+        </Box>
+      </Paper>
+
+      {/* Sub-tabs */}
+      <Tabs value={subTab} onChange={(_, v) => setSubTab(v)} sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}>
+        <Tab label="Utility Programs" />
+        <Tab label="Program Size Table" />
+        <Tab label="Command Sets" />
+      </Tabs>
+
+      {/* ── Utility Programs tab ─────────────────────────────────────────── */}
+      {subTab === 0 && (
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+
+            {/* Utility + Rating */}
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Program Design</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Utility</InputLabel>
+                  <Select value={s.utilityId} label="Utility"
+                    onChange={e => {
+                      set('utilityId', e.target.value);
+                      // clear any options that don't apply to the new utility
+                      const newUtil = SR2Utilities.find(u => u.id === e.target.value);
+                      setS(d => ({
+                        ...d,
+                        utilityId: e.target.value,
+                        selectedOptions: d.selectedOptions.filter(o => newUtil?.availableOptions.includes(o.id)),
+                      }));
+                    }}
+                  >
+                    {SR2Utilities.map(u => (
+                      <MenuItem key={u.id} value={u.id}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Chip label={u.type} size="small" color={TYPE_COLORS[u.type] ?? 'default'} sx={{ fontSize: '0.65rem', height: 18 }} />
+                          {u.label} (×{u.mult})
+                        </Box>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <Box>
+                  <TextField
+                    label="Rating"
+                    type="number" size="small" sx={{ width: 120 }}
+                    value={s.rating}
+                    onChange={e => set('rating', Math.max(1, Math.min(14, +e.target.value)))}
+                    inputProps={{ min: 1, max: 14 }}
+                    error={s.rating > maxRating}
+                    helperText={s.rating > maxRating ? `Capped at ${maxRating}` : `Max: ${maxRating}`}
+                  />
+                </Box>
+              </Box>
+
+              {utility.systemOps && (
+                <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+                  <Typography variant="caption"><strong>System Operations:</strong> {utility.systemOps}</Typography>
+                </Alert>
+              )}
+
+              {/* Base size chips */}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                <Chip color="primary" label={`Base size: ${fmt(baseSize)} Mp (rating ${rating}² × ${utility.mult})`} />
+                {selOpts.length > 0 && actualSizeMp !== baseSize && (
+                  <Chip label={`Actual size: ${fmt(actualSizeMp)} Mp (with options)`} color="primary" variant="outlined" />
+                )}
+                {selOpts.length > 0 && designSizeMp !== actualSizeMp && (
+                  <Chip label={`Design size: ${fmt(designSizeMp)} Mp (for time)`} variant="outlined" />
+                )}
+              </Box>
+            </Paper>
+
+            {/* Options */}
+            {availOpts.length > 0 ? (
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Utility Options
+                  <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                    (VR2 pp.103–104 — options change design/actual size and effective rating, NOT the programming TN)
+                  </Typography>
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {availOpts.map(opt => {
+                    const sel = selOpts.find(o => o.id === opt.id);
+                    const isSelected = !!sel;
+                    const modLabel = typeof opt.ratingMod === 'number'
+                      ? ` (${opt.ratingMod > 0 ? '+' : ''}${opt.ratingMod})`
+                      : opt.ratingMod === 'per_area_rating' || opt.ratingMod === 'per_dinab_rating' || opt.ratingMod === 'per_stealth_rating'
+                        ? ' (+rating)'
+                        : ' (special)';
+                    return (
+                      <Box key={opt.id} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                        <Tooltip title={opt.notes} placement="top" arrow>
+                          <Chip
+                            label={`${opt.label}${modLabel}`}
+                            size="small"
+                            variant={isSelected ? 'filled' : 'outlined'}
+                            color={isSelected ? 'primary' : 'default'}
+                            onClick={() => toggleOption(opt.id)}
+                            sx={{ cursor: 'pointer' }}
+                          />
+                        </Tooltip>
+                        {isSelected && opt.ratingMod === 'per_area_rating' && (
+                          <TextField label="Area Rating" type="number" size="small" sx={{ width: 130 }}
+                            value={sel.areaRating ?? 1}
+                            onChange={e => setOptSubRating(opt.id, 'areaRating', Math.max(1, +e.target.value))}
+                            inputProps={{ min: 1, max: rating }}
+                          />
+                        )}
+                        {isSelected && opt.ratingMod === 'per_dinab_rating' && (
+                          <TextField label="DINAB Rating" type="number" size="small" sx={{ width: 130 }}
+                            value={sel.dinabRating ?? 1}
+                            onChange={e => setOptSubRating(opt.id, 'dinabRating', Math.max(1, +e.target.value))}
+                            inputProps={{ min: 1, max: rating }}
+                          />
+                        )}
+                        {isSelected && opt.ratingMod === 'per_stealth_rating' && (
+                          <TextField label="Stealth Rating" type="number" size="small" sx={{ width: 130 }}
+                            value={sel.skulkRating ?? 1}
+                            onChange={e => setOptSubRating(opt.id, 'skulkRating', Math.max(1, +e.target.value))}
+                            inputProps={{ min: 1, max: rating }}
+                          />
+                        )}
+                      </Box>
+                    );
+                  })}
+                </Box>
+                {selOpts.length > 0 && effectiveRating !== rating && (
+                  <Box sx={{ mt: 1 }}>
+                    <Chip size="small" color="secondary" label={`Effective rating: ${effectiveRating} (base ${rating})`} />
+                  </Box>
+                )}
+              </Paper>
+            ) : (
+              utility.availableOptions.length === 0 && (
+                <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+                  <Typography variant="caption">No utility options available for {utility.label}.</Typography>
+                </Alert>
+              )
+            )}
+
+            {/* Programming Setup */}
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Programming Setup</Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                <FormControl size="small" sx={{ minWidth: 280 }}>
+                  <InputLabel>Tools / Environment</InputLabel>
+                  <Select value={s.toolId} label="Tools / Environment" onChange={e => set('toolId', e.target.value)}>
+                    {SR2ProgrammingTools.map(t => (
+                      <MenuItem key={t.id} value={t.id}>
+                        {t.label} {t.taskBonus > 0 ? `(+${t.taskBonus} task bonus)` : '(no bonus)'}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <TextField
+                  label="Team Members"
+                  type="number" size="small" sx={{ width: 140 }}
+                  value={s.teamMembers}
+                  onChange={e => set('teamMembers', Math.max(1, Math.min(sr2MaxTeamSize(s.skill), +e.target.value)))}
+                  inputProps={{ min: 1, max: sr2MaxTeamSize(s.skill) }}
+                  helperText={`Max: ${sr2MaxTeamSize(s.skill)} (skill÷2)`}
+                />
+              </Box>
+              {tool.notes && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
+                  {tool.notes}
+                </Typography>
+              )}
+              {tool.costNote && (
+                <Typography variant="caption" color="text.secondary" display="block">
+                  Cost: {tool.costNote}
+                </Typography>
+              )}
+              {s.teamMembers > 1 && (
+                <Alert severity="info" sx={{ mt: 1 }} icon={false}>
+                  <Typography variant="caption">
+                    Team: max rating {sr2MaxTeamRating(s.skill)} · each additional member reduces task period by 1 day · average skills for Computer Test (round up) · sum all task bonuses ÷ members = team task bonus
+                  </Typography>
+                </Alert>
+              )}
+            </Paper>
+
+          </Grid>
+
+          {/* Right column */}
+          <Grid item xs={12} md={5}>
+            <Box sx={{ position: 'sticky', top: 80 }}>
+
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  Computer Skill (or Software / Matrix Programming) vs TN {tn}
+                </Typography>
+                <Chip color="primary" label={`TN: ${tn} (= program rating)`} />
+                {tool.taskBonus > 0 && (
+                  <Box sx={{ mt: 1 }}>
+                    <Chip color="secondary" size="small" label={`+${s.teamMembers > 1 ? Math.floor(tool.taskBonus / s.teamMembers) : tool.taskBonus} task bonus (${tool.label})`} />
+                  </Box>
+                )}
+              </Paper>
+
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Task Period</Typography>
+                <TextField
+                  label="Successes on Computer Test"
+                  type="number" size="small" fullWidth
+                  value={s.successes}
+                  onChange={e => set('successes', Math.max(1, +e.target.value))}
+                  inputProps={{ min: 1 }} sx={{ mb: 1 }}
+                />
+                <StatRow label="Design size" value={`${fmt(designSizeMp)} Mp`} />
+                <StatRow label="Base time (size × 2)" value={fmtDays(baseTimeDays)} />
+                <StatRow label="Task period (base ÷ successes)" value={fmtDays(taskPeriod)} highlight
+                  caption={`${fmt(taskPeriod * 8)} hrs total work`} />
+                {s.teamMembers > 1 && (
+                  <StatRow
+                    label={`Team reduction (${s.teamMembers - 1} extra member${s.teamMembers > 2 ? 's' : ''})`}
+                    value={`−${s.teamMembers - 1} day${s.teamMembers > 2 ? 's' : ''}/day worked`}
+                  />
+                )}
+              </Paper>
+
+              <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="subtitle2" gutterBottom>Summary</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  <Chip size="small" color={TYPE_COLORS[utility.type] ?? 'default'} label={`${utility.label} (${utility.type})`} />
+                  <Chip size="small" label={`Rating ${rating}${effectiveRating !== rating ? ` → eff. ${effectiveRating}` : ''}`} />
+                  <Chip size="small" label={`×${utility.mult} mult`} />
+                  <Chip size="small" color="primary" label={`${fmt(actualSizeMp)} Mp actual`} />
+                  {designSizeMp !== actualSizeMp && <Chip size="small" label={`${fmt(designSizeMp)} Mp design`} />}
+                  <Chip size="small" label={`TN ${tn}`} />
+                  {tool.taskBonus > 0 && <Chip size="small" color="secondary" label={`+${tool.taskBonus} task`} />}
+                  {selOpts.length > 0 && <Chip size="small" label={`${selOpts.length} option${selOpts.length > 1 ? 's' : ''}`} />}
+                </Box>
+              </Paper>
+
+              {/* Quick Reference */}
+              <Accordion variant="outlined">
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2">Quick Reference</Typography>
+                </AccordionSummary>
+                <AccordionDetails sx={{ p: 1 }}>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Program Size:</strong> Rating² × Multiplier (Mp)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Size × 2 days (1 day = 8 hrs)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Period:</strong> Base time ÷ successes</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>TN:</strong> Program rating</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = Computer Skill (deck/frame cores: skill × 1.5, round down)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Bonuses:</strong> Kit +1 · Shop +2 · Mainframe +4 · Mainframe+Suite +5 · Double memory +1</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Options (actual size):</strong> One-Shot ×0.25 · Optimization ×0.5 · Squeeze ×0.5 · Sensitive ×0.25</Typography>
+                  <Typography variant="caption" display="block"><strong>Options (design size):</strong> One-Shot ×1.5 · Optimization ×2 · Sensitive ×1.5</Typography>
+                </AccordionDetails>
+              </Accordion>
+            </Box>
+          </Grid>
+        </Grid>
+      )}
+
+      {/* ── Program Size Table tab ───────────────────────────────────────── */}
+      {subTab === 1 && (
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Program Size Table (VR2 p.101) — Rating² × Multiplier (Mp)
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Highlighted row = current rating ({rating}). All values in megapulses (Mp).
+          </Typography>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell><strong>Rating</strong></TableCell>
+                  {[1,2,3,4,5,6,7,8,9,10].map(m => <TableCell key={m} align="center"><strong>×{m}</strong></TableCell>)}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {[1,2,3,4,5,6,7,8,9,10,11,12,13,14].map(r => (
+                  <TableRow key={r} sx={r === rating ? { bgcolor: 'action.selected' } : {}}>
+                    <TableCell><strong>{r}{r === rating ? ' ★' : ''}</strong></TableCell>
+                    {[1,2,3,4,5,6,7,8,9,10].map(m => (
+                      <TableCell key={m} align="center"
+                        sx={r === rating && m === utility.mult ? { fontWeight: 'bold', color: 'primary.main' } : {}}>
+                        {r * r * m}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      )}
+
+      {/* ── Command Sets tab ─────────────────────────────────────────────── */}
+      {subTab === 2 && (
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Command Sets (VR2 p.104)</Typography>
+          <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+            <Typography variant="caption">
+              A command set is a simple program of orders left on a host to be executed at a later time. Writing a command set requires one or more Subsystem Tests. The Deception utility reduces TN for all command set tests.
+            </Typography>
+          </Alert>
+          <Typography variant="body2" color="text.secondary">
+            The gamemaster determines the specific Subsystem Test needed for each task in the command set (when in doubt, use a Control Test). Command sets are all tasks, with specific base times, task periods, and tests needed to complete the work (see <em>Deckers and Tasks</em>, VR2 p.77).
+          </Typography>
+          <Alert severity="warning" sx={{ mt: 2 }} icon={false}>
+            <Typography variant="caption">
+              Full command set rules will be filled in from the VR2 scan. Check back after the book scan is available.
+            </Typography>
+          </Alert>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/src/components/SR2ProgrammingCalculator.js
+++ b/src/components/SR2ProgrammingCalculator.js
@@ -4,15 +4,21 @@ import {
   FormControl, InputLabel, Select, MenuItem,
   TextField, Tooltip, Grid, Table, TableBody,
   TableCell, TableContainer, TableHead, TableRow,
-  Accordion, AccordionSummary, AccordionDetails, Tabs, Tab,
+  Accordion, AccordionSummary, AccordionDetails,
+  Tabs, Tab, ToggleButton, ToggleButtonGroup, Divider,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   SR2Utilities, SR2UtilityOptions, SR2ProgrammingTools,
+  SR2FrameTypes,
   sr2ProgramSize, sr2MaxRating, sr2BaseTimeDays, sr2TaskPeriod,
   sr2CalcEffectiveRating, sr2CalcActualSize, sr2CalcDesignSize,
-  sr2MaxTeamSize, sr2MaxTeamRating,
+  sr2MaxTeamSize,
+  sr2FrameCoreSize, sr2LoadingRating, sr2LoadingSize, sr2LoadingBaseTime, sr2AvgProgramRating,
+  sr2UpgradeBaseTime,
+  sr2ProgramPrice, sr2ProgramPriceTier,
+  SR2_COMMAND_SET_DESIGN_SIZES,
 } from '../data/SR2/ProgrammingRules';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -51,15 +57,271 @@ const TYPE_COLORS = {
   special:     'warning',
 };
 
+const FRAME_OPT_IDS = ['dinab', 'optimization', 'squeeze'];
+
+// ── Frames & Agents tab ───────────────────────────────────────────────────────
+const frameDefault = {
+  frameType: 'dumb',
+  coreRating: 4,
+  bod: 1, evasion: 1, masking: 1, sensor: 1,
+  initPoints: 0,
+  dinabRating: 1,
+  selectedOptions: [],
+  loadedPrograms: [{ rating: 4, mult: 3 }],
+  successes: 2,
+};
+
+function FrameCalculator({ skill }) {
+  const [f, setF] = useState(frameDefault);
+  const ff = (k, v) => setF(d => ({ ...d, [k]: v }));
+
+  const frameType   = SR2FrameTypes.find(t => t.id === f.frameType) ?? SR2FrameTypes[0];
+  const maxCore     = sr2MaxRating(skill, true);
+  const coreRating  = Math.min(f.coreRating, maxCore);
+  const coreSizeMp  = sr2FrameCoreSize(coreRating, f.frameType);
+
+  const attrTotal   = f.bod + f.evasion + f.masking + f.sensor;
+  const initAlloc   = frameType.hasInitiative ? f.initPoints : 0;
+  const corePoints  = coreRating; // total Core Rating Points to distribute
+  const pointsUsed  = attrTotal + initAlloc;
+  const pointsLeft  = corePoints - pointsUsed;
+
+  // DINAB rating capped at Computer Skill
+  const dinabRating = Math.min(f.dinabRating, skill);
+
+  // Frame options: DINAB, Optimization, Squeeze only
+  const frameOpts = SR2UtilityOptions.filter(o => FRAME_OPT_IDS.includes(o.id));
+
+  function toggleOpt(id) {
+    setF(d => {
+      const has = d.selectedOptions.find(o => o.id === id);
+      return has
+        ? { ...d, selectedOptions: d.selectedOptions.filter(o => o.id !== id) }
+        : { ...d, selectedOptions: [...d.selectedOptions, { id }] };
+    });
+  }
+
+  // Frame loading calculation
+  const programRatings = f.loadedPrograms.map(p => p.rating);
+  const loadingRating  = sr2LoadingRating(programRatings);
+  const loadingSize    = sr2LoadingSize(loadingRating);
+  const loadingBase    = sr2LoadingBaseTime(loadingRating);
+  const avgRating      = sr2AvgProgramRating(programRatings);
+  const loadingPeriod  = sr2TaskPeriod(loadingBase, f.successes);
+
+  const programSizes   = f.loadedPrograms.map(p => sr2ProgramSize(p.rating, p.mult));
+  const totalFrameSize = coreSizeMp + programSizes.reduce((a, b) => a + b, 0);
+
+  function addProgram() {
+    setF(d => ({ ...d, loadedPrograms: [...d.loadedPrograms, { rating: 4, mult: 3 }] }));
+  }
+  function removeProgram(i) {
+    setF(d => ({ ...d, loadedPrograms: d.loadedPrograms.filter((_, j) => j !== i) }));
+  }
+  function setProgramField(i, key, val) {
+    setF(d => {
+      const progs = [...d.loadedPrograms];
+      progs[i] = { ...progs[i], [key]: val };
+      return { ...d, loadedPrograms: progs };
+    });
+  }
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={7}>
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Frame Core</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel>Frame Type</InputLabel>
+              <Select value={f.frameType} label="Frame Type" onChange={e => ff('frameType', e.target.value)}>
+                {SR2FrameTypes.map(t => <MenuItem key={t.id} value={t.id}>{t.label} (×{t.coreMult})</MenuItem>)}
+              </Select>
+            </FormControl>
+            <Box>
+              <TextField
+                label="Core Rating"
+                type="number" size="small" sx={{ width: 130 }}
+                value={f.coreRating}
+                onChange={e => ff('coreRating', Math.max(1, Math.min(20, +e.target.value)))}
+                inputProps={{ min: 1, max: 20 }}
+                error={f.coreRating > maxCore}
+                helperText={f.coreRating > maxCore ? `Capped at ${maxCore}` : `Max: ${maxCore} (skill×1.5)`}
+              />
+            </Box>
+          </Box>
+
+          <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+            <Typography variant="caption">{frameType.notes}</Typography>
+          </Alert>
+
+          {/* Core Rating Points allocation */}
+          <Typography variant="subtitle2" gutterBottom>
+            Core Rating Points — {coreRating} total
+            <Typography component="span" variant="caption" color={pointsLeft < 0 ? 'error' : 'text.secondary'} sx={{ ml: 1 }}>
+              {pointsLeft < 0 ? `Over by ${-pointsLeft}` : `${pointsLeft} remaining`}
+            </Typography>
+          </Typography>
+          {pointsLeft < 0 && <Alert severity="error" sx={{ mb: 1, py: 0.5 }} icon={false}>Attributes + Initiative exceed Core Rating — reduce allocations.</Alert>}
+
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
+            {[['bod','Bod'],['evasion','Evasion'],['masking','Masking'],['sensor','Sensor']].map(([k, lbl]) => (
+              <TextField key={k}
+                label={lbl} type="number" size="small" sx={{ width: 90 }}
+                value={f[k]}
+                onChange={e => ff(k, Math.max(0, +e.target.value))}
+                inputProps={{ min: 0, max: coreRating }}
+                error={f[k] > coreRating}
+              />
+            ))}
+            {frameType.hasInitiative && (
+              <Box>
+                <TextField
+                  label="Init Dice Points"
+                  type="number" size="small" sx={{ width: 130 }}
+                  value={f.initPoints}
+                  onChange={e => ff('initPoints', Math.max(0, +e.target.value))}
+                  inputProps={{ min: 0, max: coreRating }}
+                />
+                <Typography variant="caption" color="text.secondary" display="block">
+                  = {1 + f.initPoints}D6 Initiative
+                </Typography>
+              </Box>
+            )}
+          </Box>
+
+          {/* DINAB rating (smart frames required, dumb optional) */}
+          {f.selectedOptions.find(o => o.id === 'dinab') || frameType.hasDINABRequired ? (
+            <Box sx={{ mb: 2 }}>
+              <TextField
+                label={`DINAB Rating ${frameType.hasDINABRequired ? '(required)' : '(optional)'}`}
+                type="number" size="small" sx={{ width: 200 }}
+                value={f.dinabRating}
+                onChange={e => ff('dinabRating', Math.max(1, Math.min(skill, +e.target.value)))}
+                inputProps={{ min: 1, max: skill }}
+                helperText={`Max: ${skill} (= Computer Skill)`}
+              />
+            </Box>
+          ) : null}
+
+          {/* Frame options */}
+          <Typography variant="subtitle2" gutterBottom>Frame Core Options (DINAB, Optimization, Squeeze only)</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+            {frameOpts.map(opt => {
+              const sel = f.selectedOptions.find(o => o.id === opt.id);
+              const isSelected = !!sel;
+              if (opt.id === 'dinab' && frameType.hasDINABRequired) return null; // smart always has it
+              return (
+                <Tooltip key={opt.id} title={opt.notes} placement="top" arrow>
+                  <Chip
+                    label={opt.label}
+                    size="small"
+                    variant={isSelected ? 'filled' : 'outlined'}
+                    color={isSelected ? 'primary' : 'default'}
+                    onClick={() => toggleOpt(opt.id)}
+                    sx={{ cursor: 'pointer' }}
+                  />
+                </Tooltip>
+              );
+            })}
+          </Box>
+
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <Chip color="primary" label={`Core size: ${fmt(coreSizeMp)} Mp (${coreRating}² × ${frameType.coreMult})`} />
+          </Box>
+        </Paper>
+
+        {/* Frame Loading */}
+        <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Frame Loading (VR2 p.106)
+            <InfoTip text="Loading Rating = sum of program ratings ÷ 2 (round down). Loading size = Loading Rating². Base time = Loading size × 2 days. Computer Test vs average program rating." />
+          </Typography>
+
+          {f.loadedPrograms.map((prog, i) => (
+            <Box key={i} sx={{ display: 'flex', gap: 1, mb: 1, alignItems: 'center' }}>
+              <TextField label={`Program ${i + 1} Rating`} type="number" size="small" sx={{ width: 140 }}
+                value={prog.rating}
+                onChange={e => setProgramField(i, 'rating', Math.max(1, +e.target.value))}
+                inputProps={{ min: 1 }}
+              />
+              <TextField label="Multiplier" type="number" size="small" sx={{ width: 100 }}
+                value={prog.mult}
+                onChange={e => setProgramField(i, 'mult', Math.max(1, Math.min(20, +e.target.value)))}
+                inputProps={{ min: 1, max: 20 }}
+              />
+              <Typography variant="caption" color="text.secondary">{fmt(sr2ProgramSize(prog.rating, prog.mult))} Mp</Typography>
+              {f.loadedPrograms.length > 1 && (
+                <Chip label="×" size="small" onClick={() => removeProgram(i)} sx={{ cursor: 'pointer' }} />
+              )}
+            </Box>
+          ))}
+          <Chip label="+ Add Program" size="small" variant="outlined" onClick={addProgram} sx={{ cursor: 'pointer', mb: 2 }} />
+
+          <StatRow label="Loading Rating (ratings ÷ 2)" value={loadingRating} />
+          <StatRow label="Loading size (LR²)" value={`${fmt(loadingSize)} Mp`} />
+          <StatRow label="Loading base time (size × 2)" value={fmtDays(loadingBase)} />
+          <StatRow label="Avg program rating (TN)" value={avgRating} />
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={5}>
+        <Box sx={{ position: 'sticky', top: 80 }}>
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Loading Task Period</Typography>
+            <TextField
+              label="Computer Test Successes"
+              type="number" size="small" fullWidth
+              value={f.successes}
+              onChange={e => ff('successes', Math.max(1, +e.target.value))}
+              inputProps={{ min: 1 }} sx={{ mb: 1 }}
+            />
+            <StatRow label="Loading base time" value={fmtDays(loadingBase)} />
+            <StatRow label="Loading task period" value={fmtDays(loadingPeriod)} highlight />
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>Frame Summary</Typography>
+            <StatRow label="Core Rating" value={coreRating} />
+            <StatRow label="Core size" value={`${fmt(coreSizeMp)} Mp`} />
+            <StatRow label="Loaded programs size" value={`${fmt(programSizes.reduce((a,b)=>a+b,0))} Mp`} />
+            <StatRow label="Total frame size" value={`${fmt(totalFrameSize)} Mp`} highlight />
+            {frameType.hasInitiative && <StatRow label="Initiative" value={`${1 + f.initPoints}D6 + ${coreRating}`} />}
+            {frameType.hasInitiative && <StatRow label="Reaction" value={coreRating} />}
+            <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Chip size="small" color={f.frameType === 'smart' ? 'secondary' : 'default'} label={frameType.label} />
+              <Chip size="small" label={`Bod ${f.bod} / Evasion ${f.evasion}`} />
+              <Chip size="small" label={`Masking ${f.masking} / Sensor ${f.sensor}`} />
+              {(f.selectedOptions.find(o => o.id === 'dinab') || frameType.hasDINABRequired) && (
+                <Chip size="small" color="secondary" label={`DINAB ${dinabRating}`} />
+              )}
+            </Box>
+          </Paper>
+
+          <Alert severity="info" icon={false}>
+            <Typography variant="caption">
+              <strong>Core Rating used in place of MPCP</strong> for all MPCP tests.<br />
+              Programs may not be loaded partial — if a program isn't smaller, it's incomplete and won't work.<br />
+              Combined option ratings of all programs may not exceed Core Rating. Deckers may re-use frame cores with different utility combinations (cannot rearrange attributes — write a new core).
+            </Typography>
+          </Alert>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 const defaultState = {
   skill: 6,
   utilityId: 'analyze',
   rating: 4,
-  selectedOptions: [],   // [{ id, areaRating?, dinabRating?, skulkRating? }]
+  selectedOptions: [],
   toolId: 'personal_computer',
   teamMembers: 1,
   successes: 2,
+  upgradeMode: false,
+  oldRating: 3,
 };
 
 export default function SR2ProgrammingCalculator() {
@@ -70,17 +332,24 @@ export default function SR2ProgrammingCalculator() {
   const utility = SR2Utilities.find(u => u.id === s.utilityId) ?? SR2Utilities[0];
   const tool    = SR2ProgrammingTools.find(t => t.id === s.toolId) ?? SR2ProgrammingTools[0];
 
-  const maxRating      = sr2MaxRating(s.skill, false);
-  const rating         = Math.min(s.rating, maxRating);
+  const maxRating       = sr2MaxRating(s.skill, false);
+  const rating          = Math.min(s.rating, maxRating);
   const effectiveRating = sr2CalcEffectiveRating(rating, s.selectedOptions);
-  const actualSizeMp   = sr2CalcActualSize(rating, utility.mult, s.selectedOptions);
-  const designSizeMp   = sr2CalcDesignSize(rating, utility.mult, s.selectedOptions);
-  const baseSize       = sr2ProgramSize(rating, utility.mult);
-  const baseTimeDays   = sr2BaseTimeDays(designSizeMp);
-  const taskPeriod     = sr2TaskPeriod(baseTimeDays, s.successes);
-  const tn             = rating; // TN = program rating
+  const actualSizeMp    = sr2CalcActualSize(rating, utility.mult, s.selectedOptions);
+  const designSizeMp    = sr2CalcDesignSize(rating, utility.mult, s.selectedOptions);
+  const baseSize        = sr2ProgramSize(rating, utility.mult);
+  const tn              = rating;
+
+  const baseTimeDays = s.upgradeMode
+    ? sr2UpgradeBaseTime(rating, Math.min(s.oldRating, rating - 1), utility.mult)
+    : sr2BaseTimeDays(designSizeMp);
+  const taskPeriod = sr2TaskPeriod(baseTimeDays, s.successes);
+
+  const priceTier = sr2ProgramPriceTier(rating);
+  const priceInfo = sr2ProgramPrice(rating, actualSizeMp);
 
   const availOpts = SR2UtilityOptions.filter(o => utility.availableOptions.includes(o.id));
+  const selOpts   = s.selectedOptions;
 
   function toggleOption(id) {
     setS(d => {
@@ -97,8 +366,6 @@ export default function SR2ProgrammingCalculator() {
     }));
   }
 
-  const selOpts = s.selectedOptions;
-
   return (
     <Box sx={{ p: 2, maxWidth: 1100 }}>
       <Typography variant="h5" gutterBottom>
@@ -106,7 +373,7 @@ export default function SR2ProgrammingCalculator() {
         <Chip label="SR2 / VR2 Rules" size="small" variant="outlined" sx={{ ml: 1, fontSize: '0.7rem' }} color="secondary" />
       </Typography>
       <Typography variant="body2" color="text.secondary" gutterBottom>
-        Calculate programming time, TNs and task periods for SR2 deckers. Source: <em>Virtual Realities 2.0</em> pp. 101–104, 161.
+        Calculate programming time, TNs and task periods for SR2 deckers. Source: <em>Virtual Realities 2.0</em> pp. 101–107, 161.
       </Typography>
 
       {/* Shared character section */}
@@ -119,7 +386,7 @@ export default function SR2ProgrammingCalculator() {
             value={s.skill}
             onChange={e => set('skill', Math.max(1, Math.min(12, +e.target.value)))}
             inputProps={{ min: 1, max: 12 }}
-            helperText={`Max utility rating: ${maxRating}`}
+            helperText={`Max utility rating: ${maxRating} · Max frame core: ${sr2MaxRating(s.skill, true)}`}
           />
         </Box>
       </Paper>
@@ -127,6 +394,7 @@ export default function SR2ProgrammingCalculator() {
       {/* Sub-tabs */}
       <Tabs value={subTab} onChange={(_, v) => setSubTab(v)} sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}>
         <Tab label="Utility Programs" />
+        <Tab label="Frames" />
         <Tab label="Program Size Table" />
         <Tab label="Command Sets" />
       </Tabs>
@@ -136,16 +404,22 @@ export default function SR2ProgrammingCalculator() {
         <Grid container spacing={2}>
           <Grid item xs={12} md={7}>
 
-            {/* Utility + Rating */}
             <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
               <Typography variant="subtitle2" gutterBottom>Program Design</Typography>
+
+              <Box sx={{ mb: 2 }}>
+                <ToggleButtonGroup value={s.upgradeMode ? 'upgrade' : 'new'} exclusive size="small"
+                  onChange={(_, v) => { if (v) set('upgradeMode', v === 'upgrade'); }}>
+                  <ToggleButton value="new">New Program</ToggleButton>
+                  <ToggleButton value="upgrade">Upgrade Existing</ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
                 <FormControl size="small" sx={{ minWidth: 220 }}>
                   <InputLabel>Utility</InputLabel>
                   <Select value={s.utilityId} label="Utility"
                     onChange={e => {
-                      set('utilityId', e.target.value);
-                      // clear any options that don't apply to the new utility
                       const newUtil = SR2Utilities.find(u => u.id === e.target.value);
                       setS(d => ({
                         ...d,
@@ -176,6 +450,21 @@ export default function SR2ProgrammingCalculator() {
                     helperText={s.rating > maxRating ? `Capped at ${maxRating}` : `Max: ${maxRating}`}
                   />
                 </Box>
+
+                {s.upgradeMode && (
+                  <Box>
+                    <TextField
+                      label="Current (old) Rating"
+                      type="number" size="small" sx={{ width: 150 }}
+                      value={s.oldRating}
+                      onChange={e => set('oldRating', Math.max(1, Math.min(rating - 1, +e.target.value)))}
+                      inputProps={{ min: 1, max: Math.max(1, rating - 1) }}
+                    />
+                    <Typography variant="caption" color="text.secondary" display="block">
+                      Must be less than {rating}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
 
               {utility.systemOps && (
@@ -184,11 +473,10 @@ export default function SR2ProgrammingCalculator() {
                 </Alert>
               )}
 
-              {/* Base size chips */}
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                <Chip color="primary" label={`Base size: ${fmt(baseSize)} Mp (rating ${rating}² × ${utility.mult})`} />
+                <Chip color="primary" label={`Base size: ${fmt(baseSize)} Mp (${rating}² × ${utility.mult})`} />
                 {selOpts.length > 0 && actualSizeMp !== baseSize && (
-                  <Chip label={`Actual size: ${fmt(actualSizeMp)} Mp (with options)`} color="primary" variant="outlined" />
+                  <Chip label={`Actual size: ${fmt(actualSizeMp)} Mp`} color="primary" variant="outlined" />
                 )}
                 {selOpts.length > 0 && designSizeMp !== actualSizeMp && (
                   <Chip label={`Design size: ${fmt(designSizeMp)} Mp (for time)`} variant="outlined" />
@@ -197,12 +485,12 @@ export default function SR2ProgrammingCalculator() {
             </Paper>
 
             {/* Options */}
-            {availOpts.length > 0 ? (
+            {availOpts.length > 0 && (
               <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
                 <Typography variant="subtitle2" gutterBottom>
                   Utility Options
                   <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-                    (VR2 pp.103–104 — options change design/actual size and effective rating, NOT the programming TN)
+                    Options change design/actual size and effective rating — NOT the programming TN
                   </Typography>
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
@@ -211,9 +499,7 @@ export default function SR2ProgrammingCalculator() {
                     const isSelected = !!sel;
                     const modLabel = typeof opt.ratingMod === 'number'
                       ? ` (${opt.ratingMod > 0 ? '+' : ''}${opt.ratingMod})`
-                      : opt.ratingMod === 'per_area_rating' || opt.ratingMod === 'per_dinab_rating' || opt.ratingMod === 'per_stealth_rating'
-                        ? ' (+rating)'
-                        : ' (special)';
+                      : ' (+rating)';
                     return (
                       <Box key={opt.id} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                         <Tooltip title={opt.notes} placement="top" arrow>
@@ -257,12 +543,6 @@ export default function SR2ProgrammingCalculator() {
                   </Box>
                 )}
               </Paper>
-            ) : (
-              utility.availableOptions.length === 0 && (
-                <Alert severity="info" sx={{ mb: 2 }} icon={false}>
-                  <Typography variant="caption">No utility options available for {utility.label}.</Typography>
-                </Alert>
-              )
             )}
 
             {/* Programming Setup */}
@@ -294,36 +574,23 @@ export default function SR2ProgrammingCalculator() {
                 </Typography>
               )}
               {tool.costNote && (
-                <Typography variant="caption" color="text.secondary" display="block">
-                  Cost: {tool.costNote}
-                </Typography>
-              )}
-              {s.teamMembers > 1 && (
-                <Alert severity="info" sx={{ mt: 1 }} icon={false}>
-                  <Typography variant="caption">
-                    Team: max rating {sr2MaxTeamRating(s.skill)} · each additional member reduces task period by 1 day · average skills for Computer Test (round up) · sum all task bonuses ÷ members = team task bonus
-                  </Typography>
-                </Alert>
+                <Typography variant="caption" color="text.secondary" display="block">Cost: {tool.costNote}</Typography>
               )}
             </Paper>
-
           </Grid>
 
           {/* Right column */}
           <Grid item xs={12} md={5}>
             <Box sx={{ position: 'sticky', top: 80 }}>
-
               <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
                 <Typography variant="subtitle2" gutterBottom>Programming Test</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                   Computer Skill (or Software / Matrix Programming) vs TN {tn}
                 </Typography>
-                <Chip color="primary" label={`TN: ${tn} (= program rating)`} />
-                {tool.taskBonus > 0 && (
-                  <Box sx={{ mt: 1 }}>
-                    <Chip color="secondary" size="small" label={`+${s.teamMembers > 1 ? Math.floor(tool.taskBonus / s.teamMembers) : tool.taskBonus} task bonus (${tool.label})`} />
-                  </Box>
-                )}
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  <Chip color="primary" label={`TN: ${tn} (= program rating)`} />
+                  {tool.taskBonus > 0 && <Chip color="secondary" size="small" label={`+${tool.taskBonus} task bonus`} />}
+                </Box>
               </Paper>
 
               <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
@@ -335,46 +602,68 @@ export default function SR2ProgrammingCalculator() {
                   onChange={e => set('successes', Math.max(1, +e.target.value))}
                   inputProps={{ min: 1 }} sx={{ mb: 1 }}
                 />
-                <StatRow label="Design size" value={`${fmt(designSizeMp)} Mp`} />
-                <StatRow label="Base time (size × 2)" value={fmtDays(baseTimeDays)} />
+                {s.upgradeMode ? (
+                  <>
+                    <StatRow label={`New size (rating ${rating})`} value={`${fmt(sr2ProgramSize(rating, utility.mult))} Mp`} />
+                    <StatRow label={`Old size (rating ${Math.min(s.oldRating, rating-1)})`} value={`${fmt(sr2ProgramSize(Math.min(s.oldRating, rating-1), utility.mult))} Mp`} />
+                    <StatRow label="Upgrade base time (difference × 2)" value={fmtDays(baseTimeDays)} />
+                  </>
+                ) : (
+                  <StatRow label={`Design size`} value={`${fmt(designSizeMp)} Mp`} />
+                )}
+                <StatRow label={s.upgradeMode ? 'Base time' : 'Base time (size × 2)'} value={fmtDays(baseTimeDays)} />
                 <StatRow label="Task period (base ÷ successes)" value={fmtDays(taskPeriod)} highlight
                   caption={`${fmt(taskPeriod * 8)} hrs total work`} />
                 {s.teamMembers > 1 && (
-                  <StatRow
-                    label={`Team reduction (${s.teamMembers - 1} extra member${s.teamMembers > 2 ? 's' : ''})`}
-                    value={`−${s.teamMembers - 1} day${s.teamMembers > 2 ? 's' : ''}/day worked`}
-                  />
+                  <StatRow label={`Each extra member`} value="−1 day/day worked" />
                 )}
               </Paper>
+
+              {/* Program Price */}
+              {priceInfo && (
+                <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+                  <Typography variant="subtitle2" gutterBottom>Buying This Program (VR2 p.107)</Typography>
+                  <StatRow label="Actual size" value={`${fmt(actualSizeMp)} Mp`} />
+                  <StatRow label={`Price (size × ${priceTier?.priceMult})`} value={`¥${priceInfo.price.toLocaleString()}`} highlight />
+                  <StatRow label="Availability" value={priceInfo.avail} />
+                  <StatRow label="Street Index" value={priceInfo.streetIndex} />
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
+                    Option ratings do not affect price. Availability: Etiquette (Matrix) skill. −25% for object-code only.
+                  </Typography>
+                </Paper>
+              )}
 
               <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
                 <Typography variant="subtitle2" gutterBottom>Summary</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   <Chip size="small" color={TYPE_COLORS[utility.type] ?? 'default'} label={`${utility.label} (${utility.type})`} />
                   <Chip size="small" label={`Rating ${rating}${effectiveRating !== rating ? ` → eff. ${effectiveRating}` : ''}`} />
-                  <Chip size="small" label={`×${utility.mult} mult`} />
+                  <Chip size="small" label={`×${utility.mult}`} />
                   <Chip size="small" color="primary" label={`${fmt(actualSizeMp)} Mp actual`} />
                   {designSizeMp !== actualSizeMp && <Chip size="small" label={`${fmt(designSizeMp)} Mp design`} />}
                   <Chip size="small" label={`TN ${tn}`} />
                   {tool.taskBonus > 0 && <Chip size="small" color="secondary" label={`+${tool.taskBonus} task`} />}
                   {selOpts.length > 0 && <Chip size="small" label={`${selOpts.length} option${selOpts.length > 1 ? 's' : ''}`} />}
+                  {s.upgradeMode && <Chip size="small" color="warning" label={`Upgrade from ${Math.min(s.oldRating, rating-1)}`} />}
                 </Box>
               </Paper>
 
-              {/* Quick Reference */}
               <Accordion variant="outlined">
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography variant="subtitle2">Quick Reference</Typography>
                 </AccordionSummary>
                 <AccordionDetails sx={{ p: 1 }}>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Program Size:</strong> Rating² × Multiplier (Mp)</Typography>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Size × 2 days (1 day = 8 hrs)</Typography>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Period:</strong> Base time ÷ successes</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Size:</strong> Rating² × Mult (Mp)</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Base Time:</strong> Design size × 2 days</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Upgrade Base Time:</strong> (New size − Old size) × 2 days</Typography>
                   <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>TN:</strong> Program rating</Typography>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = Computer Skill (deck/frame cores: skill × 1.5, round down)</Typography>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Bonuses:</strong> Kit +1 · Shop +2 · Mainframe +4 · Mainframe+Suite +5 · Double memory +1</Typography>
-                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Options (actual size):</strong> One-Shot ×0.25 · Optimization ×0.5 · Squeeze ×0.5 · Sensitive ×0.25</Typography>
-                  <Typography variant="caption" display="block"><strong>Options (design size):</strong> One-Shot ×1.5 · Optimization ×2 · Sensitive ×1.5</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Rating:</strong> = Computer Skill</Typography>
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Max Deck/Frame Core:</strong> Skill × 1.5 (round down)</Typography>
+                  <Divider sx={{ my: 0.5 }} />
+                  <Typography variant="caption" display="block" sx={{ mb: 0.5 }}><strong>Task Bonuses:</strong> Kit +1 · Shop +2 · Mainframe +4 · +Suite +5 · Double memory +1</Typography>
+                  <Divider sx={{ my: 0.5 }} />
+                  <Typography variant="caption" display="block" sx={{ mb: 0.25 }}><strong>Prices:</strong></Typography>
+                  <Typography variant="caption" display="block" sx={{ pl: 1 }}>R1–3: ×100¥ · R4–6: ×200¥ · R7–9: ×500¥ · R10+: ×1000¥</Typography>
                 </AccordionDetails>
               </Accordion>
             </Box>
@@ -382,14 +671,14 @@ export default function SR2ProgrammingCalculator() {
         </Grid>
       )}
 
+      {/* ── Frames tab ───────────────────────────────────────────────────── */}
+      {subTab === 1 && <FrameCalculator skill={s.skill} />}
+
       {/* ── Program Size Table tab ───────────────────────────────────────── */}
-      {subTab === 1 && (
+      {subTab === 2 && (
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Typography variant="subtitle2" gutterBottom>
             Program Size Table (VR2 p.101) — Rating² × Multiplier (Mp)
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Highlighted row = current rating ({rating}). All values in megapulses (Mp).
           </Typography>
           <TableContainer>
             <Table size="small">
@@ -401,13 +690,10 @@ export default function SR2ProgrammingCalculator() {
               </TableHead>
               <TableBody>
                 {[1,2,3,4,5,6,7,8,9,10,11,12,13,14].map(r => (
-                  <TableRow key={r} sx={r === rating ? { bgcolor: 'action.selected' } : {}}>
-                    <TableCell><strong>{r}{r === rating ? ' ★' : ''}</strong></TableCell>
+                  <TableRow key={r}>
+                    <TableCell><strong>{r}</strong></TableCell>
                     {[1,2,3,4,5,6,7,8,9,10].map(m => (
-                      <TableCell key={m} align="center"
-                        sx={r === rating && m === utility.mult ? { fontWeight: 'bold', color: 'primary.main' } : {}}>
-                        {r * r * m}
-                      </TableCell>
+                      <TableCell key={m} align="center">{r * r * m}</TableCell>
                     ))}
                   </TableRow>
                 ))}
@@ -418,23 +704,78 @@ export default function SR2ProgrammingCalculator() {
       )}
 
       {/* ── Command Sets tab ─────────────────────────────────────────────── */}
-      {subTab === 2 && (
-        <Paper variant="outlined" sx={{ p: 2 }}>
-          <Typography variant="subtitle2" gutterBottom>Command Sets (VR2 p.104)</Typography>
-          <Alert severity="info" sx={{ mb: 2 }} icon={false}>
-            <Typography variant="caption">
-              A command set is a simple program of orders left on a host to be executed at a later time. Writing a command set requires one or more Subsystem Tests. The Deception utility reduces TN for all command set tests.
-            </Typography>
-          </Alert>
-          <Typography variant="body2" color="text.secondary">
-            The gamemaster determines the specific Subsystem Test needed for each task in the command set (when in doubt, use a Control Test). Command sets are all tasks, with specific base times, task periods, and tests needed to complete the work (see <em>Deckers and Tasks</em>, VR2 p.77).
-          </Typography>
-          <Alert severity="warning" sx={{ mt: 2 }} icon={false}>
-            <Typography variant="caption">
-              Full command set rules will be filled in from the VR2 scan. Check back after the book scan is available.
-            </Typography>
-          </Alert>
-        </Paper>
+      {subTab === 3 && (
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+            <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Command Sets (VR2 pp.104–105)</Typography>
+              <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+                <Typography variant="caption">
+                  A command set is a simple program of orders that a decker can leave on a host to be executed at a later time. Writing a command set requires one or more Subsystem Tests depending on the tasks the decker wants the host to perform. The Deception utility reduces TN for all command set tests.
+                </Typography>
+              </Alert>
+
+              <Typography variant="subtitle2" gutterBottom>Design Size</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Design size is <strong>1D6 × 20 Mp</strong> (random, determined at write time). After uploading the program, the decker must make a successful Control Test to load it into the host.
+              </Typography>
+              <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Die Roll</TableCell>
+                      <TableCell align="center">Design Size</TableCell>
+                      <TableCell align="center">Base Time (×2)</TableCell>
+                      <TableCell align="center">2 successes</TableCell>
+                      <TableCell align="center">4 successes</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {SR2_COMMAND_SET_DESIGN_SIZES.map((mp, i) => {
+                      const base = mp * 2;
+                      return (
+                        <TableRow key={i}>
+                          <TableCell>{i + 1}</TableCell>
+                          <TableCell align="center">{mp} Mp</TableCell>
+                          <TableCell align="center">{fmtDays(base)}</TableCell>
+                          <TableCell align="center">{fmtDays(Math.ceil(base / 2))}</TableCell>
+                          <TableCell align="center">{fmtDays(Math.ceil(base / 4))}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <Typography variant="subtitle2" gutterBottom>Runtime Duration</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                After the command set is loaded, the host makes Subsystem Test rolls opposing the decker. Total the host's successes and divide by 24 — this is the number of hours the command set will continue running undetected before being found and purged. If the host scores no successes, the command set remains undetected for <strong>48 hours</strong>.
+              </Typography>
+
+              <Typography variant="subtitle2" gutterBottom>What Tests to Use</Typography>
+              <Typography variant="body2" color="text.secondary">
+                The gamemaster determines the specific Subsystem Test for each task in the command set. When in doubt, use a Control Test. Examples: opening a security door → Access Test; printing something → Files Test; opening a system → Access Test.
+              </Typography>
+            </Paper>
+          </Grid>
+
+          <Grid item xs={12} md={5}>
+            <Paper variant="outlined" sx={{ p: 2 }}>
+              <Typography variant="subtitle2" gutterBottom>Quick Reference (Skill {s.skill})</Typography>
+              <StatRow label="Design size" value="1D6 × 20 Mp (random)" />
+              <StatRow label="Base time" value="Design size × 2 days" />
+              <StatRow label="Min base time (roll 1)" value={fmtDays(40)} />
+              <StatRow label="Max base time (roll 6)" value={fmtDays(240)} />
+              <StatRow label="Upload" value="Successful Control Test required" />
+              <StatRow label="Runtime if host fails" value="48 hours undetected" highlight />
+              <StatRow label="Runtime formula" value="Host successes ÷ 24 hrs" />
+              <Divider sx={{ my: 1 }} />
+              <Typography variant="caption" color="text.secondary" display="block">
+                Cannot be upgraded (VR2 p.107). Use the Deception utility to reduce TN on all command set Subsystem Tests.
+              </Typography>
+            </Paper>
+          </Grid>
+        </Grid>
       )}
     </Box>
   );

--- a/src/data/SR2/ProgrammingRules.js
+++ b/src/data/SR2/ProgrammingRules.js
@@ -1,0 +1,297 @@
+// SR2 Programming Rules — Virtual Realities 2.0
+// Sources: VR2 pp. 101–104, 161
+
+// ── Utilities Table (VR2 p.161) ───────────────────────────────────────────────
+// type: 'operational' | 'defensive' | 'offensive' | 'special'
+// availableOptions: option ids that can be applied to this utility
+export const SR2Utilities = [
+  { id: 'analyze',      label: 'Analyze',      type: 'operational', mult: 3,  systemOps: 'Analyze IC/Icon/Security, Locate IC',    availableOptions: [] },
+  { id: 'armor',        label: 'Armor',        type: 'defensive',   mult: 3,  systemOps: null,                                     availableOptions: ['optimization'] },
+  { id: 'attack_l',     label: 'Attack-L',     type: 'offensive',   mult: 2,  systemOps: null,                                     availableOptions: ['area','chaser','dinab','limit','one_shot','optimization','penetration','skulk','targeting'] },
+  { id: 'attack_m',     label: 'Attack-M',     type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['area','chaser','dinab','limit','one_shot','optimization','penetration','skulk','targeting'] },
+  { id: 'attack_s',     label: 'Attack-S',     type: 'offensive',   mult: 4,  systemOps: null,                                     availableOptions: ['area','chaser','dinab','limit','one_shot','optimization','penetration','skulk','targeting'] },
+  { id: 'attack_d',     label: 'Attack-D',     type: 'offensive',   mult: 5,  systemOps: null,                                     availableOptions: ['area','chaser','dinab','limit','one_shot','optimization','penetration','skulk','targeting'] },
+  { id: 'black_hammer', label: 'Black Hammer', type: 'offensive',   mult: 20, systemOps: null,                                     availableOptions: ['one_shot','optimization','targeting'] },
+  { id: 'browse',       label: 'Browse',       type: 'operational', mult: 1,  systemOps: 'Locate Access Node/File/Slave',          availableOptions: [] },
+  { id: 'camo',         label: 'Camo',         type: 'defensive',   mult: 3,  systemOps: null,                                     availableOptions: ['one_shot','optimization'] },
+  { id: 'cloak',        label: 'Cloak',        type: 'defensive',   mult: 3,  systemOps: null,                                     availableOptions: ['one_shot','optimization'] },
+  { id: 'commlink',     label: 'Commlink',     type: 'operational', mult: 1,  systemOps: 'Retrain, Tap Comcall',                   availableOptions: [] },
+  { id: 'compressor',   label: 'Compressor',   type: 'special',     mult: 2,  systemOps: null,                                     availableOptions: [] },
+  { id: 'crash',        label: 'Crash',        type: 'operational', mult: 3,  systemOps: 'Crash Application/Host',                 availableOptions: [] },
+  { id: 'defuse',       label: 'Defuse',       type: 'defensive',   mult: 2,  systemOps: null,                                     availableOptions: [] },
+  { id: 'deception',    label: 'Deception',    type: 'operational', mult: 2,  systemOps: 'Graceful Logoff/Logon',                  availableOptions: [] },
+  { id: 'decrypt',      label: 'Decrypt',      type: 'operational', mult: 1,  systemOps: 'Decrypt Access/File/Slave',              availableOptions: [] },
+  { id: 'disinfect',    label: 'Disinfect',    type: 'operational', mult: 2,  systemOps: 'Disinfect',                              availableOptions: [] },
+  { id: 'evaluate',     label: 'Evaluate',     type: 'operational', mult: 2,  systemOps: 'Locate Paydata',                         availableOptions: [] },
+  { id: 'hog',          label: 'Hog',          type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['dinab','one_shot','optimization','targeting'] },
+  { id: 'killjoy',      label: 'Killjoy',      type: 'offensive',   mult: 10, systemOps: null,                                     availableOptions: ['one_shot','optimization','targeting'] },
+  { id: 'lock_on',      label: 'Lock-on',      type: 'defensive',   mult: 3,  systemOps: null,                                     availableOptions: ['one_shot','optimization'] },
+  { id: 'medic',        label: 'Medic',        type: 'defensive',   mult: 4,  systemOps: null,                                     availableOptions: ['dinab','optimization'] },
+  { id: 'mirrors',      label: 'Mirrors',      type: 'operational', mult: 3,  systemOps: 'Decoy',                                  availableOptions: [] },
+  { id: 'poison',       label: 'Poison',       type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['area','dinab','one_shot','optimization','targeting'] },
+  { id: 'read_write',   label: 'Read/Write',   type: 'operational', mult: 2,  systemOps: 'Download/Upload Data, Edit File',        availableOptions: [] },
+  { id: 'relocate',     label: 'Relocate',     type: 'operational', mult: 2,  systemOps: null,                                     availableOptions: [] },
+  { id: 'restore',      label: 'Restore',      type: 'defensive',   mult: 3,  systemOps: null,                                     availableOptions: ['dinab','one_shot','optimization'] },
+  { id: 'restrict',     label: 'Restrict',     type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['area','dinab','one_shot','optimization','targeting'] },
+  { id: 'reveal',       label: 'Reveal',       type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['area','dinab','one_shot','optimization','targeting'] },
+  { id: 'scanner',      label: 'Scanner',      type: 'operational', mult: 3,  systemOps: 'Locate Decker/Frame',                   availableOptions: [] },
+  { id: 'shield',       label: 'Shield',       type: 'defensive',   mult: 4,  systemOps: null,                                     availableOptions: ['optimization'] },
+  { id: 'sleaze',       label: 'Sleaze',       type: 'special',     mult: 3,  systemOps: null,                                     availableOptions: [] },
+  { id: 'slow',         label: 'Slow',         type: 'offensive',   mult: 4,  systemOps: null,                                     availableOptions: ['area','dinab','one_shot','optimization','targeting'] },
+  { id: 'spoof',        label: 'Spoof',        type: 'operational', mult: 3,  systemOps: 'Command/Edit/Monitor Slave',             availableOptions: [] },
+  { id: 'steamroller',  label: 'Steamroller',  type: 'offensive',   mult: 3,  systemOps: null,                                     availableOptions: ['dinab','one_shot','optimization','targeting'] },
+  { id: 'track',        label: 'Track',        type: 'special',     mult: 8,  systemOps: null,                                     availableOptions: [] },
+  { id: 'validate',     label: 'Validate',     type: 'operational', mult: 4,  systemOps: 'Dump Log, Validate Passcode',            availableOptions: [] },
+];
+
+// ── Utility Options (VR2 pp.103–104) ─────────────────────────────────────────
+// ratingMod: numeric modifier to rating (or 'special' / 'per_rating')
+// actualSizeMod: multiplier applied to actual size (0.5 = ×0.5 = half)
+// designSizeMod: multiplier applied to design size (2.0 = double)
+// notes: plain-English rule summary
+export const SR2UtilityOptions = [
+  {
+    id: 'area',
+    label: 'Area',
+    ratingMod: 'per_area_rating',
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '+Area Rating to program rating. Targets = area rating. Each additional target beyond the first raises TN by 2 for that target. Personas and IC programs carrying Armor gain +2 to effective Armor Rating when attacked by Area utilities.',
+  },
+  {
+    id: 'chaser',
+    label: 'Chaser',
+    ratingMod: 1,
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: 'Negates the +2 TN penalty for attacking IC programs with the Shift defensive utility. Adds +2 TN against targets using Shield. Cannot be combined with Penetration.',
+  },
+  {
+    id: 'dinab',
+    label: 'DINAB',
+    ratingMod: 'per_dinab_rating',
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '"Decker in a box." +DINAB Rating. The decker may spend a Free Action and two Simple Actions to run all DINAB-equipped utilities simultaneously. Degrades 1 Rating Point each time it fails a test. Crashes on all-1s. Requires Swap Memory operation to reload.',
+  },
+  {
+    id: 'limit',
+    label: 'Limit',
+    ratingMod: -1,
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '−1 to rating. Restricts utility to a single target type (deckers, IC, frames, or SKs). Useless against any other target type. Also reduces actual size (since rating is lower).',
+  },
+  {
+    id: 'one_shot',
+    label: 'One-Shot',
+    ratingMod: 'special',
+    actualSizeMod: 0.25,
+    designSizeMod: 1.5,
+    notes: 'Single use — utility vanishes after executing once. Decker must reload it with a Swap Memory operation to use again. Actual size ×0.25 (−75%). Design size ×1.5 (+50%). A Tar Baby/Tar Pit IC trashes all copies of a one-shot program in active memory.',
+  },
+  {
+    id: 'optimization',
+    label: 'Optimization',
+    ratingMod: 'special',
+    actualSizeMod: 0.5,
+    designSizeMod: 2.0,
+    notes: 'Reduces actual size by 50% (×0.5). Increases design size by 100% (×2). Reduces memory footprint at the cost of longer programming time.',
+  },
+  {
+    id: 'penetration',
+    label: 'Penetration',
+    ratingMod: 1,
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '+1 to rating. Defeats the Shield defensive utility. Against IC programs with the Shift defensive utility, suffers a +2 TN penalty. Cannot be combined with Chaser.',
+  },
+  {
+    id: 'sensitive',
+    label: 'Sensitive',
+    ratingMod: 'special',
+    actualSizeMod: 0.25,
+    designSizeMod: 1.5,
+    notes: 'Makes utility effective only on one manufacturer\'s mainframes. Requires in-depth knowledge of the Matrix architecture of different computer systems. Actual size ×0.25 (−75%). Design size ×1.5 (+50%).',
+  },
+  {
+    id: 'skulk',
+    label: 'Skulk',
+    ratingMod: 'per_stealth_rating',
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '+Stealth Rating. When used to crash an IC program, reduces or eliminates additions to the security tally. Reduce the resulting security tally increase by the Skulk Rating.',
+  },
+  {
+    id: 'squeeze',
+    label: 'Squeeze',
+    ratingMod: 1,
+    actualSizeMod: 0.5,
+    designSizeMod: null,
+    notes: '+1 to rating. Self-compressed program. Actual size ×0.5 for upload/memory purposes. Cannot be used until decompressed (Complex Action to decompress; no test required). If uploaded while squeezed using the Compressor utility, actual size is ×0.25 (−75%) total and design size is only increased by the Squeeze modifier.',
+  },
+  {
+    id: 'targeting',
+    label: 'Targeting',
+    ratingMod: 2,
+    actualSizeMod: null,
+    designSizeMod: null,
+    notes: '+2 to rating. Provides −2 target-number modifier for attacks made with targeting-equipped combat utilities.',
+  },
+];
+
+// ── Program Size (VR2 p.101) ──────────────────────────────────────────────────
+// Size = Rating² × Multiplier (in Mp)
+export function sr2ProgramSize(rating, multiplier) {
+  return rating * rating * multiplier;
+}
+
+// Pre-calculated size table (ratings 1–14, multipliers 1–10)
+export function sr2SizeTable() {
+  const rows = [];
+  for (let r = 1; r <= 14; r++) {
+    const cols = {};
+    for (let m = 1; m <= 10; m++) {
+      cols[m] = r * r * m;
+    }
+    rows.push({ rating: r, ...cols });
+  }
+  return rows;
+}
+
+// ── Programming Rules (VR2 pp.101–102) ───────────────────────────────────────
+
+// Maximum program rating (VR2 p.101)
+// Deck/frame core programs: skill × 1.5 (round down)
+// All other programs: = skill rating
+export function sr2MaxRating(skill, isDeckOrFrame = false) {
+  if (isDeckOrFrame) return Math.floor(skill * 1.5);
+  return skill;
+}
+
+// Base time in days = program size × 2 (VR2 p.102)
+export function sr2BaseTimeDays(sizeMp) {
+  return sizeMp * 2;
+}
+
+// Task period in days = base time ÷ successes (VR2 p.101)
+export function sr2TaskPeriod(baseTimeDays, successes) {
+  if (!successes || successes < 1) return baseTimeDays;
+  return Math.ceil(baseTimeDays / successes);
+}
+
+// Programming TN = program rating (VR2 p.101)
+// Test: Computer Skill (or Software concentration / Matrix Programming specialization)
+export function sr2ProgrammingTN(rating) {
+  return rating;
+}
+
+// ── Programming Tools (VR2 p.102) ────────────────────────────────────────────
+export const SR2ProgrammingTools = [
+  {
+    id: 'personal_computer',
+    label: 'Personal Computer',
+    taskBonus: 0,
+    costNote: '20¥/Mp of memory required',
+    notes: 'Minimum setup needed. Memory must equal or exceed program size. Miniature decks cost more (VR2 p.259, SRII).',
+  },
+  {
+    id: 'double_memory',
+    label: 'Double Required Memory',
+    taskBonus: 1,
+    costNote: '20¥/Mp of memory (double)',
+    notes: '+1 task bonus. Computer has at least double the required memory for the program.',
+  },
+  {
+    id: 'programming_kit',
+    label: 'Programming Kit',
+    taskBonus: 1,
+    costNote: '1,500¥',
+    notes: 'Basic tool suite installed in personal computer. +1 task bonus. Cannot be used on a mainframe.',
+  },
+  {
+    id: 'programming_shop',
+    label: 'Programming Shop',
+    taskBonus: 2,
+    costNote: '15,000¥',
+    notes: 'More elaborate package. +2 task bonus. Doubles memory in personal computer. If computer already has doubled memory, quadruples it and gives +3 total bonus (−1 for doubled memory, +2 for shop).',
+  },
+  {
+    id: 'mainframe_host',
+    label: 'Mainframe Host (access)',
+    taskBonus: 4,
+    costNote: '100¥ × Security Value per day (5,000,000¥ to purchase)',
+    notes: '+4 task bonus. Mainframe\'s Security Value must be at least half the rating of the program. Cost per day = Security Value × 100¥. Companies have very active security — Validate Passcode counterfeit risk.',
+  },
+  {
+    id: 'mainframe_suite',
+    label: 'Mainframe + Programming Suite',
+    taskBonus: 5,
+    costNote: '100¥ × Security Value per day (300,000¥ suite to purchase)',
+    notes: '+5 task bonus. Programming suite on mainframe adds +1 to the mainframe host bonus. Suite costs 300,000¥ and is useless without a mainframe. Programming time: Security Value × 200¥/day.',
+  },
+];
+
+// ── Design Size with Options ──────────────────────────────────────────────────
+// Options affect actual size and/or design size independently.
+// Apply all rating modifiers first, then percentage size changes sequentially.
+// VR2 p.103: "When layering multiple options on a single program, apply any changes
+// to the program's rating before calculating any percentage changes in its size."
+
+export function sr2CalcEffectiveRating(baseRating, selectedOptions) {
+  let rating = baseRating;
+  selectedOptions.forEach(opt => {
+    const def = SR2UtilityOptions.find(o => o.id === opt.id);
+    if (!def) return;
+    if (typeof def.ratingMod === 'number') rating += def.ratingMod;
+    if (def.id === 'area' && opt.areaRating)   rating += opt.areaRating;
+    if (def.id === 'dinab' && opt.dinabRating)  rating += opt.dinabRating;
+    if (def.id === 'skulk' && opt.skulkRating)  rating += opt.skulkRating;
+  });
+  return Math.max(1, rating);
+}
+
+export function sr2CalcActualSize(baseRating, multiplier, selectedOptions) {
+  const effectiveRating = sr2CalcEffectiveRating(baseRating, selectedOptions);
+  let size = effectiveRating * effectiveRating * multiplier;
+  // Apply sequential percentage changes to actual size
+  selectedOptions.forEach(opt => {
+    const def = SR2UtilityOptions.find(o => o.id === opt.id);
+    if (!def || def.actualSizeMod == null) return;
+    size = size * def.actualSizeMod;
+  });
+  return Math.round(size);
+}
+
+export function sr2CalcDesignSize(baseRating, multiplier, selectedOptions) {
+  const effectiveRating = sr2CalcEffectiveRating(baseRating, selectedOptions);
+  let size = effectiveRating * effectiveRating * multiplier;
+  // Apply sequential percentage changes to design size
+  selectedOptions.forEach(opt => {
+    const def = SR2UtilityOptions.find(o => o.id === opt.id);
+    if (!def || def.designSizeMod == null) return;
+    size = size * def.designSizeMod;
+  });
+  return Math.round(size);
+}
+
+// ── Programming Teams (VR2 p.102) ────────────────────────────────────────────
+// Max team size = highest Computer Skill ÷ 2 (round down)
+// Max program rating = 1 + highest Computer Skill
+// Average all skills (round up) for Computer Test
+// Sum all task bonuses, divide by number of programmers = team's task bonus
+// Each day a team member works reduces task period by 1 day
+
+export function sr2MaxTeamSize(highestSkill) {
+  return Math.floor(highestSkill / 2);
+}
+
+export function sr2MaxTeamRating(highestSkill) {
+  return 1 + highestSkill;
+}
+
+export function sr2TeamTaskBonus(toolBonuses) {
+  // toolBonuses: array of task bonuses per member
+  const total = toolBonuses.reduce((a, b) => a + b, 0);
+  return Math.floor(total / toolBonuses.length);
+}

--- a/src/data/SR2/ProgrammingRules.js
+++ b/src/data/SR2/ProgrammingRules.js
@@ -295,3 +295,113 @@ export function sr2TeamTaskBonus(toolBonuses) {
   const total = toolBonuses.reduce((a, b) => a + b, 0);
   return Math.floor(total / toolBonuses.length);
 }
+
+// ── Command Sets (VR2 p.105) ──────────────────────────────────────────────────
+// Design size: 1D6 × 20 Mp
+// Upload: decker must perform a successful Control Test to load the program
+// Host scores successes against Subsystem Tests; sum ÷ 24 = hours the command
+// set will continue running undetected. If host scores no successes: 48 hrs.
+export const SR2_COMMAND_SET_DESIGN_SIZES = [20, 40, 60, 80, 100, 120]; // 1D6 × 20 Mp
+
+export function sr2CommandSetBaseTime(designSizeMp) {
+  return designSizeMp * 2; // days, same formula as other programs
+}
+
+// ── Frames (VR2 pp.105–106) ──────────────────────────────────────────────────
+// Frame Core: Rating² × Frame Core Multiplier
+// Dumb frame multiplier: 2  |  Smart frame multiplier: 3
+// Max Core Rating: Computer Skill × 1.5 (round down) — same as deck/frame rule
+// Options available: DINAB, Optimization, Squeeze only
+// Attributes (Bod, Evasion, Masking, Sensor): combined may not exceed Core Rating; any can be 0
+// Core Rating used in place of MPCP for any test requiring MPCP
+// Smart Frame Reaction = Core Rating
+
+export const SR2FrameTypes = [
+  {
+    id: 'dumb',
+    label: 'Dumb Frame',
+    coreMult: 2,
+    hasDINABRequired: false,
+    hasInitiative: false,
+    notes: 'Linked to decker\'s persona; only exists as long as controlling decker is active on the host. Executes programs on a Simple Action command. Cannot repeat an action — a second attack requires a second command. Logs off if decker logs off. May include DINAB option (optional), which can trigger one program per given action.',
+  },
+  {
+    id: 'smart',
+    label: 'Smart Frame',
+    coreMult: 3,
+    hasDINABRequired: true,
+    hasInitiative: true,
+    notes: 'Capable of independent existence in the Matrix. Must be programmed with DINAB option (rating = Computer Skill). Decker gives a Free Action order, then frame acts on its own. Has own Reaction (= Core Rating) and Initiative (1D6 + Init dice from Core Rating Points). DINAB rating cannot exceed programmer\'s Computer Skill.',
+  },
+];
+
+// Frame Core actual size (always dumb or smart multiplier, no options change this directly)
+export function sr2FrameCoreSize(coreRating, frameType) {
+  const ft = SR2FrameTypes.find(t => t.id === frameType) ?? SR2FrameTypes[0];
+  return coreRating * coreRating * ft.coreMult;
+}
+
+// Smart Frame Initiative allocation
+// Programmer allocates Core Rating Points at programming time; each point = +1 Init die
+// Unmodified smart frame rolls 1D6 for Initiative; remaining Core Rating Points go to attributes
+export function sr2FrameInitDice(initPoints) {
+  return 1 + initPoints; // base 1D6 + allocated points
+}
+
+// Frame Loading (VR2 p.106)
+// Loading Rating = combined program ratings ÷ 2 (round down)
+// Loading size = Loading Rating² (Mp)
+// Loading base time = Loading size × 2 (days)
+// Computer Test vs average rating of programs being loaded
+export function sr2LoadingRating(programRatings) {
+  const total = programRatings.reduce((a, b) => a + b, 0);
+  return Math.floor(total / 2);
+}
+export function sr2LoadingSize(loadingRating) {
+  return loadingRating * loadingRating;
+}
+export function sr2LoadingBaseTime(loadingRating) {
+  return sr2LoadingSize(loadingRating) * 2;
+}
+export function sr2AvgProgramRating(programRatings) {
+  if (!programRatings.length) return 0;
+  return Math.ceil(programRatings.reduce((a, b) => a + b, 0) / programRatings.length);
+}
+
+// Actual size of a frame = frame core size + actual size of all loaded programs + options
+export function sr2FrameTotalSize(coreSizeMp, programSizes) {
+  return coreSizeMp + programSizes.reduce((a, b) => a + b, 0);
+}
+
+// ── Upgrading Programs (VR2 p.107) ───────────────────────────────────────────
+// Can upgrade any program except command sets (must have source code)
+// Base time = base time for new rating from scratch − base time for current rating from scratch
+// TN = rating of upgraded program
+// Task period = upgrade base time ÷ Computer Test successes
+export function sr2UpgradeBaseTime(newRating, oldRating, multiplier) {
+  const newSize  = sr2ProgramSize(newRating, multiplier);
+  const oldSize  = sr2ProgramSize(oldRating, multiplier);
+  const newBase  = sr2BaseTimeDays(newSize);
+  const oldBase  = sr2BaseTimeDays(oldSize);
+  return Math.max(1, newBase - oldBase);
+}
+
+// ── Buying Programs — Program Prices Table (VR2 p.107) ───────────────────────
+// Price = size × price multiplier; option ratings do not affect price
+// Availability: Etiquette (Matrix) skill test
+export const SR2ProgramPriceTiers = [
+  { ratingMin: 1,  ratingMax: 3,        priceMult: 100,   avail: '2/7 days',   streetIndex: 1   },
+  { ratingMin: 4,  ratingMax: 6,        priceMult: 200,   avail: '4/7 days',   streetIndex: 1.5 },
+  { ratingMin: 7,  ratingMax: 9,        priceMult: 500,   avail: '8/14 days',  streetIndex: 2   },
+  { ratingMin: 10, ratingMax: Infinity, priceMult: 1000,  avail: '16/30 days', streetIndex: 3   },
+];
+
+export function sr2ProgramPrice(rating, sizeMp) {
+  const tier = SR2ProgramPriceTiers.find(t => rating >= t.ratingMin && rating <= t.ratingMax);
+  if (!tier) return null;
+  return { price: sizeMp * tier.priceMult, avail: tier.avail, streetIndex: tier.streetIndex };
+}
+
+export function sr2ProgramPriceTier(rating) {
+  return SR2ProgramPriceTiers.find(t => rating >= t.ratingMin && rating <= t.ratingMax);
+}


### PR DESCRIPTION
## Summary
- **Frames sub-tab**: dumb/smart frame selector, core rating points allocation (Bod/Evasion/Masking/Sensor/Initiative), DINAB rating, frame-valid options (DINAB/Optimization/Squeeze), full frame loading calculator with task period
- **Command Sets tab**: complete implementation replacing the stub — design size table (1D6×20 Mp, all 6 results), runtime duration rules (host successes ÷ 24 hrs; 0 successes = 48 hrs), task period columns for 2 and 4 successes
- **Upgrade mode** toggle in Utility Programs: old rating input, delta base time via `sr2UpgradeBaseTime`
- **Program Prices panel**: tier price, availability, and street index from VR2 p.107 price table
- **`ProgrammingRules.js`** additions: Frame types/helpers, upgrading helper, program price tiers/functions, Command Set size constants (VR2 pp.105–107)
- Also includes earlier commits: SR3 programming language descriptions, SR3 Miscellaneous Components gear category, SR2 programming calculator stub

## Test plan
- [ ] Switch character to SR2 edition, navigate to Programming tab
- [ ] Utility Programs: change utility, toggle upgrade mode, verify price panel updates
- [ ] Frames: select dumb vs smart, allocate Core Rating Points, verify over-budget warning, add loaded programs, check task period
- [ ] Command Sets: verify all 6 die-result rows render with correct sizes and times
- [ ] Switch to SR3 edition — verify original ProgrammingCalculator renders (not SR2 version)
- [ ] Run test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)