### PR TITLE
Add GA4 analytics events for custom item saves and edition tracking

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -8,9 +8,6 @@ const track = (eventName, params = {}) => {
 export const trackDiceRolled = (diceCount) =>
   track('dice_rolled', { dice_count: diceCount });
 
-export const trackCharacterSaved = () =>
-  track('character_saved');
-
 export const trackCharacterLoaded = () =>
   track('character_loaded');
 
@@ -22,3 +19,15 @@ export const trackCharacterFinalized = (edition, race) =>
 
 export const trackTabChanged = (tabName) =>
   track('tab_viewed', { tab_name: tabName });
+
+export const trackCustomVehicleSaved = (edition) =>
+  track('custom_vehicle_saved', { edition });
+
+export const trackCustomWeaponSaved = (edition) =>
+  track('custom_weapon_saved', { edition });
+
+export const trackCustomDeckSaved = (edition) =>
+  track('custom_deck_saved', { edition });
+
+export const trackCharacterSavedWithEdition = (edition) =>
+  track('character_saved', { edition });

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -32,7 +32,7 @@ import "./SheetDisplay.css";
 import DiceRollerTray from "./DiceRollerTray";
 import SignInPopup from "./SignInPopup";
 import { Grid } from "@mui/material";
-import { trackEditionChanged, trackTabChanged, trackCharacterFinalized } from '../analytics';
+import { trackEditionChanged, trackTabChanged, trackCharacterFinalized, trackCustomVehicleSaved, trackCustomWeaponSaved, trackCustomDeckSaved } from '../analytics';
 // import TableAttribute from "./CustomTable";
 function CustomTabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -1074,6 +1074,7 @@ export default function BasicTabs() {
             onSave={(design) => {
               const customVehicles = [...(Character.customVehicles ?? []), design];
               setCharacter({ ...Character, customVehicles });
+              trackCustomVehicleSaved(Edition);
             }}
           />
         </CustomTabPanel>
@@ -1083,6 +1084,7 @@ export default function BasicTabs() {
             onSave={(design) => {
               const customWeapons = [...(Character.customWeapons ?? []), design];
               setCharacter({ ...Character, customWeapons });
+              trackCustomWeaponSaved(Edition);
             }}
           />
         </CustomTabPanel>
@@ -1092,6 +1094,7 @@ export default function BasicTabs() {
             onSave={(design) => {
               const customDecks = [...(Character.customDecks ?? []), design];
               setCharacter({ ...Character, customDecks });
+              trackCustomDeckSaved(Edition);
             }}
           />
         </CustomTabPanel>

--- a/src/components/LoadCharacter.js
+++ b/src/components/LoadCharacter.js
@@ -3,7 +3,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Modal from "@mui/material/Modal";
 import { Grid } from "@mui/material";
-import { trackCharacterSaved, trackCharacterLoaded } from '../analytics';
+import { trackCharacterSavedWithEdition, trackCharacterLoaded } from '../analytics';
 const style = {
   position: "absolute",
   top: "50%",
@@ -66,7 +66,7 @@ export default function LoadCharacter(props) {
 
     // Clean up by revoking the object URL
     URL.revokeObjectURL(url);
-    trackCharacterSaved();
+    trackCharacterSavedWithEdition(props.Edition);
   };
 
   const LoadCharacter = (event) => {
@@ -91,6 +91,7 @@ export default function LoadCharacter(props) {
     Char.edition = props.Edition;
     let characterJSON = JSON.stringify(Char);
     localStorage.setItem("characterSlot" + saveSlot, characterJSON);
+    trackCharacterSavedWithEdition(props.Edition);
     setOpenLocalStorage(false);
   };
 


### PR DESCRIPTION
- custom_vehicle_saved, custom_weapon_saved, custom_deck_saved events fire when designs are added to character, each with edition dimension
- character_saved now includes edition dimension (both file export and localStorage save paths)
- Removed no-dimension trackCharacterSaved in favour of trackCharacterSavedWithEdition