### PR TITLE
Fix GH Actions Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -41,13 +41,13 @@ jobs:
     steps:
       # Download the build artifact
       - name: Get build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build
           path: build
       # Setup the AWS credentials
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Silences the deployment workflow warning:
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/download-artifact@v4, aws-actions/configure-aws-credentials@v4

- `actions/download-artifact@v4` → `@v8` (v7 was the first release targeting Node 24; v8 is current latest)
- `aws-actions/configure-aws-credentials@v4` → `@v6` (v6.2.1 is current latest, targets Node 24)

`actions/upload-artifact@v4` was not mentioned in the warning and is unchanged. `download-artifact@v8` maintains backward compatibility with artifacts uploaded by `upload-artifact@v4`.

## Test plan

- [ ] Merge and push to main → verify deploy workflow runs without the Node 20 deprecation warning
- [ ] Confirm artifact is successfully uploaded by the build job and downloaded by the deploy job
- [ ] Confirm S3 sync completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)