### PR TITLE
Fix MUI out-of-range warning in MagicPanel test

### DIFF
--- a/src/components/MagicPanel.test.js
+++ b/src/components/MagicPanel.test.js
@@ -10,7 +10,7 @@ const mockProps = {
   onChangeSpells: jest.fn(),
   onChangeFoci: jest.fn(),
   magicalTraditions: ["Full Magician", "Adept", "Aspected Magician"],
-  chosenTradition: "Full Magician",
+  chosenTradition: { name: "None" },
   magicalTotem: null,
   onChangeMagicalTradition: jest.fn(),
   onChangeMagicalTotem: jest.fn(),


### PR DESCRIPTION
## Summary

- `mockProps.chosenTradition` was `"Full Magician"` (a string), but `MagicPanel` reads `props.chosenTradition.name` for the MUI Select value — giving `undefined`, which triggered the MUI out-of-range warning on every test run
- Changed to `{ name: 'None' }` to match the object shape MagicPanel expects

## Test plan

- [ ] `npm test` passes with no console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)