### PR TITLE
Matrix panel: Decking stats + Otaku additions

### DIFF
--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -30,7 +30,7 @@ jobs:
         run: DISABLE_ESLINT_PLUGIN=true yarn build
       # Upload the artifact for other stages to use
       - name: Share artifact in github workflow
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: build

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -967,6 +967,8 @@ export default function BasicTabs() {
             }
             Edition={Edition}
             BooksFilter={Character.allowedBooks}
+            intelligence={parseInt(Character.attributes?.Intelligence) || 0}
+            reaction={parseInt(Character.attributes?.Reaction) || 0}
           />
         </CustomTabPanel>
         <CustomTabPanel value={value} index={9}>

--- a/src/components/DeckingPanel.js
+++ b/src/components/DeckingPanel.js
@@ -1,6 +1,6 @@
 ﻿import React, { useState } from "react";
 import Paper from "@mui/material/Paper";
-import { Grid } from "@mui/material";
+import { Chip, Grid, Tooltip } from "@mui/material";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import Table from "@mui/material/Table";
@@ -13,6 +13,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import Modal from "@mui/material/Modal";
 import SearchableSelect from "./SearchableSelect";
 import ProgramCalculatorModal from "./ProgramCalculatorModal";
+import ProgrammingCalculator from "./ProgrammingCalculator";
 import "./DeckingPanel.css";
 
 // Pre-import all edition data so Vite can bundle them (no runtime require)
@@ -30,11 +31,26 @@ const modalStyle = {
   boxShadow: 24,
   p: 4,
 };
+function calcMatrixStats(deck, intelligence, reaction) {
+  const mpcp = parseInt(deck.Persona) || 0;
+  const ri = parseInt(deck['Response Increase']) || 0;
+  const riCap = Math.min(3, Math.floor(mpcp / 4));
+  const effectiveRI = Math.min(ri, riCap);
+  const hackingPool = Math.floor((mpcp + intelligence) / 3);
+  // Pure DNI: Matrix Reaction = INT; otherwise normal Reaction. RI adds +2 per level.
+  const matrixReaction = intelligence + effectiveRI * 2;
+  const normalReaction = reaction + effectiveRI * 2;
+  return { mpcp, ri, riCap, effectiveRI, hackingPool, matrixReaction, normalReaction };
+}
+
 export default function DeckingPanel(props) {
+  const intelligence = props.intelligence ?? 0;
+  const reaction = props.reaction ?? 0;
   const rawCyberdecks = allCyberdecks[`../data/${props.Edition}/Cyberdeck.json`]?.default;
   const rawPrograms = allPrograms[`../data/${props.Edition}/Programs.json`]?.default;
   const [NewCyberdeck, setNewCyberdeck] = useState();
   const [SelectedCyberdecks, setSelectedCyberdecks] = useState(props.Decks);
+  const [progCalcOpen, setProgCalcOpen] = useState(false);
   const [NewCyberdeckIndex, setNewCyberdeckIndex] = useState(0);
   const [NewCyberdeckProgram, setNewCyberdeckProgram] = useState(0);
   const [NewCyberdeckProgramIndex, setNewCyberdeckProgramIndex] = useState(0);
@@ -281,9 +297,31 @@ export default function DeckingPanel(props) {
     if (SelectedCyberdecks.length !== 0) {
       return (
         <div>
-          {SelectedCyberdecks.map((cyberdeck, index) => (
+          {SelectedCyberdecks.map((cyberdeck, index) => {
+            const ms = calcMatrixStats(cyberdeck, intelligence, reaction);
+            return (
             <Box className="cyberdeckCard" key={index}>
               <h3>{cyberdeck.Name}</h3>
+              {/* Matrix derived stats chips */}
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1.5 }}>
+                <Tooltip title="(MPCP + INT) ÷ 3, round down (Matrix p.26)">
+                  <Chip size="small" color="primary" label={`Hacking Pool: ${ms.hackingPool}`} />
+                </Tooltip>
+                <Tooltip title="Running pure DNI: INT + RI bonus. Normal: Reaction + RI bonus. (Matrix p.20, p.160)">
+                  <Chip size="small" label={`Matrix Reaction (DNI): ${ms.matrixReaction}`} />
+                </Tooltip>
+                <Tooltip title="Reaction + RI bonus when not running pure DNI">
+                  <Chip size="small" variant="outlined" label={`Reaction (non-DNI): ${ms.normalReaction}`} />
+                </Tooltip>
+                <Tooltip title="Matrix Reaction + 1D6 base (Matrix p.24)">
+                  <Chip size="small" label={`Matrix Init (DNI): ${ms.matrixReaction} + 1D6`} />
+                </Tooltip>
+                {ms.ri > ms.riCap && (
+                  <Tooltip title={`Max RI = floor(MPCP ÷ 4) = ${ms.riCap} (Matrix p.20)`}>
+                    <Chip size="small" color="error" label={`RI ${ms.ri} exceeds cap (max ${ms.riCap})`} />
+                  </Tooltip>
+                )}
+              </Box>
               <Grid container spacing={2}>
                 <Grid size={{ xs: 5}} className="cyberDeckTable">
                   <div>
@@ -390,8 +428,10 @@ export default function DeckingPanel(props) {
                       </tr>
                       <tr>
                         <td>Response Increase:</td>
-                        <td>{parseInt(cyberdeck["Response Increase"])}</td>
-                        <td></td>
+                        <td style={ms.ri > ms.riCap ? { color: 'red', fontWeight: 'bold' } : {}}>
+                          {ms.ri}{ms.ri > ms.riCap ? ` (cap: ${ms.riCap})` : ''}
+                        </td>
+                        <td>{ms.riCap}</td>
                       </tr>
                     </tbody>
                   </table>
@@ -500,7 +540,8 @@ export default function DeckingPanel(props) {
                 </Button>
               </Grid>
             </Box>
-          ))}
+          );
+          })}
         </div>
       );
     } else {
@@ -710,6 +751,14 @@ export default function DeckingPanel(props) {
         deck={calcModalDeck}
       />
       {RenderAgents()}
+      <hr />
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+        <h2 style={{ margin: 0 }}>Programming Calculator</h2>
+        <Button variant="outlined" size="small" onClick={() => setProgCalcOpen(v => !v)}>
+          {progCalcOpen ? 'Hide' : 'Show'}
+        </Button>
+      </Box>
+      {progCalcOpen && <ProgrammingCalculator />}
     </>
   );
 }

--- a/src/components/OtakuPanel.js
+++ b/src/components/OtakuPanel.js
@@ -138,6 +138,21 @@ export default function OtakuPanel(props) {
 
   const MPCP = Math.ceil((INT + WIL + CHA) / 3);
   const hackingPool = Math.floor((MPCP + INT) / 3);
+  const Masking = Math.ceil((WIL + CHA) / 2);
+  // DF = ceil((Masking + 0) / 2) + 1 — otaku have no Sleaze utility; +1 otaku bonus (p.137)
+  const detectionFactor = Math.ceil(Masking / 2) + 1;
+
+  const CHANNEL_SKILL_NAMES = ['Access', 'Control', 'Index', 'Files', 'Slave'];
+  const getChannelSkills = () => {
+    const skills = props.currentCharacter.skills ?? [];
+    return CHANNEL_SKILL_NAMES.map(name => {
+      const found = skills.find(s => s.name === name);
+      return { name, rating: found?.rating ?? 0 };
+    });
+  };
+
+  const characterAge = parseInt(props.currentCharacter.age) || 0;
+  const submersionGradeVal = parseInt(props.submersionGrade) || 0;
 
   const OtakuPathInfo = {
     'Cyber Adept': "Complex forms are treated as 1 rating higher when used (does not affect size)",
@@ -440,6 +455,10 @@ export default function OtakuPanel(props) {
                   <td>Hacking Pool</td>
                   <td>{hackingPool}</td>
                 </tr>
+                <tr title="ceil(Masking ÷ 2) + 1 otaku bonus (Matrix p.137)">
+                  <td>Detection Factor</td>
+                  <td>{detectionFactor}</td>
+                </tr>
                 <tr>
                   <td>Memory</td>
                   <td title="Complex forms require no active memory">N/A</td>
@@ -561,6 +580,33 @@ export default function OtakuPanel(props) {
                 </TableBody>
               </Table>
             </TableContainer>
+           <p style={{ fontSize: '0.85em', color: '#888', margin: '-8px 0 8px' }}>
+             Creating a complex form costs 1 Good Karma Point (Matrix p.139). Size = Rating² × Multiplier.
+           </p>
+           <h3>Channel Skills</h3>
+           <p style={{ fontSize: '0.85em', opacity: 0.7, marginBottom: 6 }}>
+             Starting channel points = MPCP ({MPCP}). Distribute among the 5 channels. Add skills via the Skills tab.
+           </p>
+           <table style={{ marginBottom: 12 }}>
+             <thead><tr><th style={{ paddingRight: 16 }}>Channel</th><th>Rating</th></tr></thead>
+             <tbody>
+               {getChannelSkills().map(({ name, rating }) => (
+                 <tr key={name}>
+                   <td style={{ paddingRight: 16 }}>{name}</td>
+                   <td style={{ color: rating === 0 ? '#aaa' : 'inherit' }}>{rating === 0 ? '—' : rating}</td>
+                 </tr>
+               ))}
+             </tbody>
+           </table>
+           {characterAge >= 21 && (
+             <Box sx={{ mb: 2, p: 1.5, border: '1px solid #f57c00', borderRadius: 1, bgcolor: '#fff3e0' }}>
+               <strong>Fading Test Reminder</strong> (Matrix p.146)<br />
+               <span style={{ fontSize: '0.85em' }}>
+                 Age {characterAge} ≥ 21 — roll {submersionGradeVal + 1} dice vs TN {5 + (characterAge - 21)} annually.<br />
+                 Failure: lose 1 Computer (Programming) skill point.
+               </span>
+             </Box>
+           )}
            <h3>Sprites</h3>
            <p style={{ fontSize: '0.85em', opacity: 0.7 }}>
              Frame core is a complex form (×5). Persona Points = core×3 (Bod/Evasion/Masking/Sensor, each ≤ core).

--- a/src/components/Sheet/CyberdeckTable.js
+++ b/src/components/Sheet/CyberdeckTable.js
@@ -35,8 +35,11 @@ const CyberdeckTable = (props) => {
     Math.floor((INT + parseInt(mpcp || 0)) / 3) + (cyber.Hacking_Pool ?? 0);
 
   const calcMatrixReaction = (deck) => {
+    const mpcp = parseInt(deck.Persona || 0);
     const ri = parseInt(deck['Response Increase'] || deck.ResponseIncrease || 0);
-    return INT + ri * 2;
+    const riCap = Math.min(3, Math.floor(mpcp / 4));
+    const effectiveRI = Math.min(ri, riCap);
+    return { reaction: INT + effectiveRI * 2, ri, riCap, effectiveRI };
   };
 
   const CalcMemoryUsed = (deck) => {
@@ -79,8 +82,7 @@ const CyberdeckTable = (props) => {
         {props.Decks.map((deck, index) => {
           const mpcp = deck.Persona;
           const hackingPool = calcHackingPool(mpcp);
-          const matrixReaction = calcMatrixReaction(deck);
-          const ri = parseInt(deck['Response Increase'] || deck.ResponseIncrease || 0);
+          const { reaction: matrixReaction, ri, riCap, effectiveRI } = calcMatrixReaction(deck);
 
           return (
             <TableContainer
@@ -147,7 +149,9 @@ const CyberdeckTable = (props) => {
                     <TableCell align="right">{matrixReaction}</TableCell>
                     <TableCell align="right">{matrixReaction} + 3D6</TableCell>
                     <TableCell align="right">{deck['I/O Speed'] || deck.IOSpeed || '—'}</TableCell>
-                    <TableCell align="right">{ri}</TableCell>
+                    <TableCell align="right" sx={ri > riCap ? { color: 'error.main' } : {}}>
+                      {ri}{ri > riCap ? ` (cap ${riCap})` : ''}
+                    </TableCell>
                   </TableRow>
                 </TableBody>
               </Table>

--- a/src/data/SR3/ComplexForms.json
+++ b/src/data/SR3/ComplexForms.json
@@ -1,0 +1,23 @@
+[
+  { "Name": "Armor",            "Multiplyer": 3  },
+  { "Name": "Attack-L",         "Multiplyer": 2  },
+  { "Name": "Attack-M",         "Multiplyer": 3  },
+  { "Name": "Attack-S",         "Multiplyer": 4  },
+  { "Name": "Attack-D",         "Multiplyer": 5  },
+  { "Name": "Black Hammer",     "Multiplyer": 20 },
+  { "Name": "Cloak",            "Multiplyer": 3  },
+  { "Name": "Compressor",       "Multiplyer": 2  },
+  { "Name": "Erosion: Poison",  "Multiplyer": 3  },
+  { "Name": "Erosion: Restrict","Multiplyer": 3  },
+  { "Name": "Erosion: Reveal",  "Multiplyer": 3  },
+  { "Name": "Hog",              "Multiplyer": 3  },
+  { "Name": "Killjoy",          "Multiplyer": 10 },
+  { "Name": "Lock-On",          "Multiplyer": 3  },
+  { "Name": "Medic",            "Multiplyer": 4  },
+  { "Name": "Restore",          "Multiplyer": 3  },
+  { "Name": "Shield",           "Multiplyer": 4  },
+  { "Name": "Sleaze",           "Multiplyer": 3  },
+  { "Name": "Slow",             "Multiplyer": 4  },
+  { "Name": "Steamroller",      "Multiplyer": 3  },
+  { "Name": "Track",            "Multiplyer": 8  }
+]


### PR DESCRIPTION
## Summary

### Decking Panel
- Thread `intelligence` and `reaction` props from Dashboard → DeckingPanel
- Show **Hacking Pool** `(MPCP+INT)÷3`, **Matrix Reaction** (DNI and non-DNI), and **Matrix Initiative** chips on each deck card with tooltip citations (Matrix p.20/24/26)
- Highlight **Response Increase cap** violations in red with max value shown (`floor(MPCP÷4)`, max 3 levels)
- **Programming Calculator** wired in at the bottom of Decking panel with Show/Hide toggle

### Otaku Panel
- **Detection Factor** added to stats table: `ceil(Masking ÷ 2) + 1` (Matrix p.137)
- **Channel skill display**: Access/Control/Index/Files/Slave ratings pulled from character's skills list
- **Fading tracker**: orange reminder box when character age ≥ 21, showing dice pool and TN
- **Complex form karma cost** clarification: note that each CF costs 1 Good Karma to create

## Test plan
- [ ] Add SR3 cyberdeck → verify Hacking Pool, Matrix Reaction, Matrix Init chips appear
- [ ] Set MPCP=8, RI=3 → check RI cap = `floor(8÷4)=2`, verify violation shown in red
- [ ] Click Show on Programming Calculator → full calculator expands
- [ ] Set character age ≥ 21 + submersion grade → verify Fading reminder shows correct dice/TN
- [ ] Add channel skills (Access, Control, etc.) in Skills tab → verify they appear in Otaku panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)