### PR TITLE
SR3 Programming: fix language data, bug test formulas, add dice roller

### DIFF
--- a/src/components/ProgrammingCalculator.js
+++ b/src/components/ProgrammingCalculator.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  Box, Typography, TextField, Paper, Chip, Alert,
+  Box, Typography, TextField, Paper, Chip, Alert, Button,
   FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Accordion, AccordionSummary, AccordionDetails, Divider, Tooltip, Grid,
@@ -664,9 +664,22 @@ const defaultState = {
   upgradeMode: false, oldRating: 3,
 };
 
+function rollSR3OpenTest(numDice, tn) {
+  const allDice = [];
+  let pool = numDice;
+  while (pool > 0) {
+    const batch = Array.from({ length: pool }, () => Math.floor(Math.random() * 6) + 1);
+    allDice.push(...batch);
+    pool = batch.filter(d => d === 6).length; // Rule of Six: each 6 rerolls
+  }
+  const successes = allDice.filter(d => d >= tn).length;
+  return { dice: allDice, successes, tn };
+}
+
 export default function ProgrammingCalculator() {
   const [s, setS] = useState(defaultState);
   const [subTab, setSubTab] = useState(0);
+  const [bugRoll, setBugRoll] = useState(null);
   const set = (k, v) => setS(d => ({ ...d, [k]: v }));
 
   const programType = PROGRAM_TYPES.find(t => t.id === s.programType) ?? PROGRAM_TYPES[0];
@@ -703,8 +716,10 @@ export default function ProgrammingCalculator() {
   const host = HOST_COLORS.find(h => h.id === s.hostColor);
   if (host?.mod) tnMod += host.mod;
   const lang = ProgrammingLanguages.find(l => l.id === s.language);
+  if (lang?.id === 'matcomdev')  tnMod += 1;
   if (lang?.id === 'mct_iconix') tnMod -= 1;
-  if (lang?.id === 'oblong')     tnMod -= 2;
+  if (lang?.id === 'metacomm')   tnMod -= 2;
+  if (lang?.id === 'oblong')     tnMod += 2;
   const finalTN = Math.max(2, baseTN + tnMod);
 
   const compDice = s.suiteRating > 0 ? suiteCompDice(s.suiteRating, s.skill) : 0;
@@ -721,7 +736,8 @@ export default function ProgrammingCalculator() {
 
   const isMainframe = s.hostColor !== 'none';
   const bugTN = bugTestTN(rating, s.skill, optionCount, s.teamMembers, isMainframe, s.reducedTime, s.language);
-  const effectiveRating = lang?.id === 'machodev' ? rating - 1 : rating;
+  const effectiveRating = lang?.id === 'intermod' ? rating - 1 : rating;
+  const finalBugTN = Math.max(2, 4 + bugTN);
 
   return (
     <Box sx={{ p: 2, maxWidth: 1100 }}>
@@ -921,7 +937,7 @@ export default function ProgrammingCalculator() {
                     <Select value={s.language} label="Programming Language" onChange={e => set('language', e.target.value)}>
                       {ProgrammingLanguages.map(l => (
                         <MenuItem key={l.id} value={l.id}>
-                          {l.label}{l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'novatech' ? l.bugMod + '/option' : l.bugMod})` : ''}
+                          {l.label}{l.bugMod ? ` (Bug: ${l.bugMod > 0 ? '+' : ''}${l.id === 'mct_iconix' ? l.bugMod + '/option' : l.bugMod})` : ''}
                         </MenuItem>
                       ))}
                     </Select>
@@ -967,7 +983,7 @@ export default function ProgrammingCalculator() {
                 <Typography variant="caption" color="text.secondary" sx={{ ml: 1, mt: 0.3 }}>(Matrix p.81)</Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <TableContainer component={Paper} variant="outlined">
+                <TableContainer component={Paper} variant="outlined" sx={{ mb: 2 }}>
                   <Table size="small">
                     <TableHead>
                       <TableRow>
@@ -976,24 +992,69 @@ export default function ProgrammingCalculator() {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      <TableRow><TableCell>Program difficulty (−(Rating+2))</TableCell><TableCell align="right">{-(rating + 2)}</TableCell></TableRow>
-                      {optionCount > 0 && <TableRow><TableCell>Options (−(options+2))</TableCell><TableCell align="right">{-(optionCount + 2)}</TableCell></TableRow>}
-                      {s.teamMembers > 1 && <TableRow><TableCell>Team ({s.teamMembers} members)</TableCell><TableCell align="right">{-(s.teamMembers + 2)}</TableCell></TableRow>}
+                      <TableRow><TableCell>Program difficulty (−⌈Rating÷2⌉)</TableCell><TableCell align="right">{-Math.ceil(rating / 2)}</TableCell></TableRow>
+                      {optionCount > 0 && <TableRow><TableCell>Options (−⌈options÷2⌉)</TableCell><TableCell align="right">{-Math.ceil(optionCount / 2)}</TableCell></TableRow>}
+                      {s.teamMembers > 1 && <TableRow><TableCell>Team (−⌈{s.teamMembers}÷2⌉)</TableCell><TableCell align="right">{-Math.ceil(s.teamMembers / 2)}</TableCell></TableRow>}
                       {isMainframe && <TableRow><TableCell>Used mainframe</TableCell><TableCell align="right">+2</TableCell></TableRow>}
                       {s.reducedTime && <TableRow><TableCell>Reduced base time</TableCell><TableCell align="right">+3</TableCell></TableRow>}
                       {lang && lang.id !== 'none' && lang.bugMod !== 0 && (
                         <TableRow>
-                          <TableCell>{lang.label}</TableCell>
-                          <TableCell align="right">{lang.id === 'novatech' ? `${lang.bugMod} × ${optionCount} = ${lang.bugMod * optionCount}` : lang.bugMod}</TableCell>
+                          <TableCell>{lang.label}{lang.id === 'mct_iconix' ? ` (${lang.bugMod} × ${optionCount} options)` : ''}</TableCell>
+                          <TableCell align="right">{lang.id === 'mct_iconix' ? lang.bugMod * optionCount : (lang.bugMod > 0 ? '+' : '') + lang.bugMod}</TableCell>
                         </TableRow>
                       )}
                       <TableRow sx={{ bgcolor: 'action.hover' }}>
-                        <TableCell><strong>Total Bug TN modifier</strong></TableCell>
+                        <TableCell><strong>Total modifier</strong></TableCell>
                         <TableCell align="right"><strong>{bugTN >= 0 ? '+' : ''}{bugTN}</strong></TableCell>
+                      </TableRow>
+                      <TableRow>
+                        <TableCell><strong>Final Bug Test TN</strong> (base 4 + modifier)</TableCell>
+                        <TableCell align="right"><strong>{finalBugTN}</strong></TableCell>
                       </TableRow>
                     </TableBody>
                   </Table>
                 </TableContainer>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={() => setBugRoll(rollSR3OpenTest(s.skill + compDice, finalBugTN))}
+                  >
+                    Roll Bug Test
+                  </Button>
+                  <Typography variant="caption" color="text.secondary">
+                    {s.skill + compDice} dice vs TN {finalBugTN}{compDice > 0 ? ` (${s.skill} skill + ${compDice} comp)` : ''}
+                  </Typography>
+                </Box>
+
+                {bugRoll && (
+                  <Paper variant="outlined" sx={{ p: 1.5 }}>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
+                      {bugRoll.dice.map((d, i) => (
+                        <Chip
+                          key={i}
+                          size="small"
+                          label={d}
+                          color={d >= bugRoll.tn ? 'success' : 'default'}
+                          variant={d >= bugRoll.tn ? 'filled' : 'outlined'}
+                          sx={{ minWidth: 36, fontWeight: d >= bugRoll.tn ? 'bold' : 'normal' }}
+                        />
+                      ))}
+                    </Box>
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+                      <Chip
+                        color={bugRoll.successes === 0 ? 'error' : 'success'}
+                        label={`${bugRoll.successes} success${bugRoll.successes !== 1 ? 'es' : ''}`}
+                      />
+                      <Typography variant="body2">
+                        {bugRoll.successes === 0
+                          ? 'Bug is immediate — manifests on first use.'
+                          : `Bug appears every ${bugRoll.successes} use${bugRoll.successes !== 1 ? 's' : ''}.`}
+                      </Typography>
+                    </Box>
+                  </Paper>
+                )}
               </AccordionDetails>
             </Accordion>
           </Grid>
@@ -1011,13 +1072,15 @@ export default function ProgrammingCalculator() {
                   {s.doubleMem && <StatRow label="Double memory" value="−2" />}
                   {s.planSuccesses > 0 && <StatRow label={`Plan successes (×${s.planSuccesses})`} value={`−${s.planSuccesses}`} />}
                   {host?.mod && <StatRow label={host.label} value={host.mod} />}
+                  {lang?.id === 'matcomdev' && <StatRow label="MatComDev" value="+1" />}
                   {lang?.id === 'mct_iconix' && <StatRow label="MCT Iconix 7" value="−1" />}
-                  {lang?.id === 'oblong' && <StatRow label="Oblong" value="−2" />}
+                  {lang?.id === 'metacomm' && <StatRow label="Metacomm" value="−2" />}
+                  {lang?.id === 'oblong' && <StatRow label="Oblong" value="+2" />}
                 </Box>
                 <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
                   <Chip color="primary" label={`Final TN: ${finalTN}`} />
                   {compDice > 0 && <Chip color="secondary" label={`+${compDice} comp. dice`} />}
-                  {lang?.id === 'machodev' && <Chip color="warning" size="small" label={`Effective rating: ${effectiveRating} (MachoDev −1)`} />}
+                  {lang?.id === 'intermod' && <Chip color="warning" size="small" label={`Effective rating: ${effectiveRating} (InterMod −1)`} />}
                 </Box>
               </Paper>
 

--- a/src/components/ProgrammingCalculator.js
+++ b/src/components/ProgrammingCalculator.js
@@ -665,15 +665,20 @@ const defaultState = {
 };
 
 function rollSR3OpenTest(numDice, tn) {
-  const allDice = [];
-  let pool = numDice;
-  while (pool > 0) {
-    const batch = Array.from({ length: pool }, () => Math.floor(Math.random() * 6) + 1);
-    allDice.push(...batch);
-    pool = batch.filter(d => d === 6).length; // Rule of Six: each 6 rerolls
+  // Rule of Six: each die accumulates — on a 6, add 6 to total and reroll,
+  // but only while total < tn. Stop once TN is met or roll is non-6.
+  const dice = [];
+  for (let i = 0; i < numDice; i++) {
+    let total = 0;
+    let roll;
+    do {
+      roll = Math.floor(Math.random() * 6) + 1;
+      total += roll;
+    } while (roll === 6 && total < tn);
+    dice.push(total);
   }
-  const successes = allDice.filter(d => d >= tn).length;
-  return { dice: allDice, successes, tn };
+  const successes = dice.filter(d => d >= tn).length;
+  return { dice, successes, tn };
 }
 
 export default function ProgrammingCalculator() {

--- a/src/data/SR3/ProgrammingRules.js
+++ b/src/data/SR3/ProgrammingRules.js
@@ -86,13 +86,14 @@ export function planTN(rating, options) {
 // ── Programming Languages (optional rule, Matrix p.81) ────────────────────────
 export const ProgrammingLanguages = [
   { id: 'none',        label: 'None (default)',     bugMod: 0,   otherEffect: null,                                          description: null },
-  { id: 'hololisp',   label: 'HoloLISP',            bugMod: 0,   otherEffect: null,                                          description: 'No mechanical effects.' },
-  { id: 'machodev',   label: 'MachoDev',            bugMod: +4,  otherEffect: '−1 to program\'s effective rating',           description: 'Bug TN +4 · Effective program rating −1' },
-  { id: 'mct_iconix', label: 'MCT Iconix 7',        bugMod: +2,  otherEffect: '−1 to Computer (Programming) Test TN',       description: 'Bug TN +2 · Programming TN −1' },
-  { id: 'metacomm',   label: 'Metacomm',            bugMod: 0,   otherEffect: null,                                          description: 'No mechanical effects.' },
-  { id: 'novatech',   label: 'Novatech VRDrive 3',  bugMod: -1,  bugModNote: '−1 per option', otherEffect: null,             description: 'Bug TN −1 per program option' },
-  { id: 'oblong',     label: 'Oblong',              bugMod: -3,  otherEffect: '−2 to Computer (Programming) Test TN',       description: 'Bug TN −3 · Programming TN −2' },
-  { id: 'renraku',    label: 'Renraku Teng',        bugMod: -5,  otherEffect: 'Base time ×2',                               description: 'Bug TN −5 · Base programming time ×2' },
+  { id: 'hololisp',   label: 'HoloLISP',            bugMod:  0,  otherEffect: null,                                          description: 'No mechanical effects.' },
+  { id: 'intermod',   label: 'InterMod',             bugMod: +4,  otherEffect: '−1 to program\'s effective rating',           description: 'Bug TN +4 · Effective program rating −1' },
+  { id: 'matcomdev',  label: 'MatComDev',            bugMod: +2,  otherEffect: '+1 to Computer (Programming) Test TN',        description: 'Bug TN +2 · Programming TN +1' },
+  { id: 'mct_iconix', label: 'MCT Iconix 7',        bugMod: -1,  bugModNote: '−1 per option', otherEffect: '−1 to Computer (Programming) Test TN', description: 'Bug TN −1 per option · Programming TN −1' },
+  { id: 'metacomm',   label: 'Metacomm',            bugMod: -3,  otherEffect: '−2 to Computer (Programming) Test TN',        description: 'Bug TN −3 · Programming TN −2' },
+  { id: 'novatech',   label: 'Novatech VRDrive 3',  bugMod: +1,  otherEffect: '+2 when using Glitch Table',                  description: 'Bug TN +1 · +2 when using Glitch Table' },
+  { id: 'oblong',     label: 'Oblong',              bugMod: +3,  otherEffect: '+2 to Computer (Programming) Test TN',        description: 'Bug TN +3 · Programming TN +2' },
+  { id: 'renraku',    label: 'Renraku Teng',        bugMod: -5,  otherEffect: 'Base time ÷ 2',                               description: 'Bug TN −5 · Base programming time ÷ 2' },
 ];
 
 // ── Bug Test (optional rule, Matrix p.81) ────────────────────────────────────
@@ -101,13 +102,12 @@ export const ProgrammingLanguages = [
 
 export function bugTestTN(programRating, programSkill, options, teamMembers, usedMainframe, reducedTime, languageId) {
   let tn = 0;
-  // Program difficulty: −(Rating + 2, round up) — already rounded since integer
-  tn -= (programRating + 2);
-  // Less than half skill: no additional modifier listed (threshold check for GM)
-  // Options: −(options + 2, round up)
-  if (options > 0) tn -= (options + 2);
-  // Team programming: −(members + 2, round up)
-  if (teamMembers > 1) tn -= (teamMembers + 2);
+  // Program difficulty: −(Rating ÷ 2, round up)
+  tn -= Math.ceil(programRating / 2);
+  // Options: −(options ÷ 2, round up)
+  if (options > 0) tn -= Math.ceil(options / 2);
+  // Team programming: −(members ÷ 2, round up)
+  if (teamMembers > 1) tn -= Math.ceil(teamMembers / 2);
   // Used mainframe: +2
   if (usedMainframe) tn += 2;
   // Reduced base time: +3
@@ -115,7 +115,7 @@ export function bugTestTN(programRating, programSkill, options, teamMembers, use
   // Language modifier
   const lang = ProgrammingLanguages.find(l => l.id === languageId);
   if (lang && lang.bugMod) {
-    if (lang.id === 'novatech') tn += lang.bugMod * options; // -1 per option
+    if (lang.id === 'mct_iconix') tn += lang.bugMod * options; // −1 per option
     else tn += lang.bugMod;
   }
   return tn;


### PR DESCRIPTION
## Summary
- **Programming Languages corrected** against the book Bug Test Table (Matrix p.81): renamed MachoDev→InterMod, added MatComDev, fixed MCT Iconix 7 (was +2 flat, now −1/option), Metacomm (was 0/no effect, now −3 bug / −2 programming TN), Novatech VRDrive 3 (was −1/option, now +1 flat with Glitch Table bonus), Oblong (signs were flipped), Renraku Teng (base time ÷2, not ×2)
- **Bug Test formula corrected**: was `−(Rating+2)` / `−(options+2)` / `−(members+2)` — now `−⌈Rating÷2⌉` / `−⌈options÷2⌉` / `−⌈members÷2⌉` per the book table
- **Programming TN modifiers updated**: added MatComDev (+1), Metacomm (−2), corrected Oblong from −2 to +2
- **Roll Bug Test button** added to the Bug Test accordion: rolls Computer (Programming) dice vs the calculated final Bug TN, displays each die as a chip (green = success), and shows a plain-English result ("Bug appears every N uses" or "immediate" on 0 successes)
- **Rule of Six** correctly implemented per SR3 rules: each die accumulates its own total (add 6, reroll) until it meets the TN or lands non-6 — not extra pool dice

## Test plan
- [ ] Open Programming Calculator (SR3, Programming tab enabled)
- [ ] Select each language — confirm bug modifier and description match the book Bug Test Table
- [ ] Verify Bug Test breakdown shows `−⌈Rating÷2⌉` values, not `−(Rating+2)`
- [ ] Click Roll Bug Test — confirm dice appear as chips, successes highlighted green, result message shown
- [ ] Select Oblong or add conditions to push Bug TN above 6 — confirm Rule of Six fires (chips can show values > 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)