### PR TITLE
Otaku: add tribe resource Mp bonus to free complex forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,182 @@
+# AGENTS.md — Shadowrun Character Generator
+
+This file defines AI agents for use with Claude Code against this repository.
+Each agent has a clear role, scope, inputs, outputs, and known limitations.
+Invoke an agent by pasting its **Invocation Prompt** into Claude Code.
+
+---
+
+## Agent Index
+
+| Agent | Purpose | Primary Targets |
+|---|---|---|
+| [Rules Auditor](#rules-auditor) | Verify JSON data against sourcebook rules; fill `???` page numbers | `src/data/SR2/`, `src/data/SR3/` |
+
+---
+
+## Rules Auditor
+
+### Role
+
+The Rules Auditor verifies that items in the game data JSON files are accurate
+and complete. It works through a target data file entry by entry, checking each
+item against a provided sourcebook reference (PDF, OCR text, or pasted excerpt),
+and produces a structured audit report of what passed, what failed, and what
+still needs a human eye.
+
+Its secondary job is resolving `???` page numbers. If it can confirm an item
+exists on a specific page of the provided source material, it fills in the
+correct `BookPage` value and flags it for commit.
+
+### Scope
+
+**In scope:**
+- Any JSON file under `src/data/SR2/` or `src/data/SR3/`
+- Verifying item stats against provided source material
+- Filling in `???` page numbers when source material is available
+- Flagging stat mismatches, missing fields, or schema inconsistencies
+- Identifying duplicate entries
+
+**Out of scope:**
+- Inferring correct stats without source material (never guess)
+- Modifying component logic or UI files
+- Making judgment calls on ambiguous rules — flag for human review instead
+
+### Known High-Priority Targets
+
+These files have the most outstanding `???` page numbers:
+
+| File | Book | Outstanding |
+|---|---|---|
+| `src/data/SR2/Cyberware.json` | Street Samurai Catalog (`ssc`) | ~1,400+ items |
+| `src/data/SR2/AdeptPowers.json` | Street Samurai Catalog (`ssc`) | unknown |
+| `src/data/SR2/Firearms.json` | Street Samurai Catalog (`ssc`) | unknown |
+| `src/data/SR2/Spells.json` | The Grimoire 2nd Ed (`gm2`) | 188 spells |
+| `src/data/SR2/Gear.json` | Fields of Fire (`fof`) | ~60 items |
+
+### Data Schema Reference
+
+All items follow this base schema. Additional fields vary by category.
+
+```json
+{
+  "Name": "Ares Predator II",
+  "Cost": 450,
+  "Availability": "4/48hrs",
+  "Street Index": 1,
+  "Legal": "Restricted",
+  "BookPage": "sr3.285"
+}
+```
+
+`BookPage` format is `{bookCode}.{pageNumber}` — e.g. `sr3.285`, `ssc.47`, `vr2.107`.
+Book codes are defined in `src/data/Books.json`.
+Placeholder for unknown pages: `{bookCode}.???` — e.g. `ssc.???`.
+
+### Audit Report Format
+
+The agent outputs a markdown audit report for each run. Save it as
+`audits/YYYY-MM-DD-{file}-audit.md`.
+
+```markdown
+# Audit: {filename} — {date}
+Source material: {book name, edition, format}
+
+## Summary
+- Items audited: N
+- Passed: N
+- Failed (stat mismatch): N
+- Page numbers resolved: N
+- Flagged for human review: N
+- Duplicates found: N
+
+## Passed
+- Item Name (BookPage confirmed: ssc.47)
+- ...
+
+## Failed — Stat Mismatches
+### Item Name
+- Field: Cost
+- File value: 450
+- Source value: 500
+- Action: Update file
+
+### ...
+
+## Page Numbers Resolved
+- Item Name: ssc.??? → ssc.47
+- ...
+
+## Flagged for Human Review
+### Item Name
+- Reason: Item appears in both `grm` and `gm2` — which edition is correct?
+
+## Duplicates
+- Item Name appears at index 14 and index 203 — verify and remove one
+```
+
+### Workflow
+
+The agent runs in a loop over the target file. For each item:
+
+1. **Read** the item from the JSON file
+2. **Search** the provided source material for the item by name
+3. **Compare** each field against the source (Name, Cost, Availability, stats)
+4. **Classify** as: Pass / Fail / Needs Review
+5. **Resolve** `???` page number if the item is found on a specific page
+6. **Append** result to the audit report
+7. **Move to next item**
+
+After completing the file, the agent proposes a diff of suggested JSON changes
+for human review before anything is written to disk.
+
+**The agent never modifies JSON files directly without showing the diff first.**
+
+### Invocation Prompt
+
+Paste this into Claude Code to start a Rules Auditor session:
+
+```
+You are the Rules Auditor agent for the Shadowrun Character Generator.
+Read AGENTS.md for your full role definition before doing anything else.
+
+Your task today:
+- Target file: src/data/SR2/Cyberware.json   ← change this to your target
+- Source material: [paste OCR text here, or attach PDF]
+
+Work through the file entry by entry. For each item:
+1. Find it in the source material by name
+2. Compare Name, Cost, Availability, Street Index, Legal, and any stat fields
+3. Classify as Pass, Fail, or Needs Review
+4. If BookPage is ???, resolve it if you can find the page
+5. Never modify files — output a proposed diff at the end
+
+Produce an audit report in the format defined in AGENTS.md.
+Save it to audits/YYYY-MM-DD-{filename}-audit.md.
+
+Do not guess stats. If you cannot find an item in the source material, flag it
+as Needs Review and move on.
+```
+
+### Tips for Getting Good Results
+
+- **Provide source material as OCR text when possible.** A PDF attachment works
+  but OCR text in the prompt gives the agent faster, more reliable lookup.
+- **Run one file at a time.** Large JSON files (1,400+ items) should be chunked
+  into logical sections (e.g. by category or letter range) if context gets long.
+- **Review the diff before committing.** The agent will propose changes — read
+  them. It will occasionally misread a stat due to OCR artifacts.
+- **Start with a small known-good section.** Before auditing all 1,400 SSC
+  items, run 20 items you can verify manually. Confirm the agent's output is
+  accurate before trusting it at scale.
+- **The `grm` vs `gm2` problem is a human decision.** If the agent flags an
+  item as appearing in both, you need to decide which book code is canonical.
+  Do not let the agent resolve this automatically.
+
+### Limitations
+
+- The agent cannot read physical books — it needs digital source material.
+- OCR quality affects accuracy. Low-quality scans will produce more false
+  mismatches.
+- It cannot resolve genuine rules ambiguities — those get flagged, not decided.
+- Context window limits mean very large files need to be chunked manually.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,0 +1,423 @@
+# Shadowrun Character Generator — Project Context
+
+> Hand this document to a new Claude instance to get up to speed without reading the codebase.  
+> Last updated: 2026-06-23
+
+---
+
+## What This Is
+
+A web-based character generator for **Shadowrun 2nd Edition (SR2)** and **Shadowrun 3rd Edition (SR3)** tabletop RPG. It covers the full character creation workflow — priorities/point-buy, attributes, skills, cyberware, gear, magic, decking, vehicles, contacts — and also outputs a printable character sheet. There is no backend; everything runs in the browser.
+
+The live app is hosted via Firebase. The repo is at `https://github.com/criticalfault/Shadowrun-Character-Generator`.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | React 18 (functional components + hooks throughout) |
+| Build tool | Vite 5 |
+| UI library | MUI v7 (Material UI) — `@mui/material`, `@mui/icons-material` |
+| Dice | `@3d-dice/dice-box` (3D animated dice) + `@dice-roller/rpg-dice-roller` |
+| Auth / hosting | Firebase 11 (`firebase/auth`, `firebase/analytics`) |
+| Analytics | GA4 via `window.gtag` (thin wrapper in `src/analytics.js`) |
+| Error tracking | Sentry (`@sentry/react`) |
+| Drag-and-drop | `react-beautiful-dnd` |
+| Routing | `react-router-dom` v7 |
+| Tests | Jest + `@testing-library/react` |
+| Language | JavaScript (no TypeScript) |
+
+---
+
+## Repository Structure
+
+```
+src/
+├── App.js                          # Root: router, Firebase init, Sentry boundary
+├── analytics.js                    # GA4 event helpers (all tracking calls go here)
+├── components/
+│   ├── Dashboard.js                # ★ Central hub — all tabs, all state, edition switching
+│   ├── DrawerAppBar.js             # Top nav bar
+│   ├── LoadCharacter.js            # Save/load: file export, localStorage slots, Firebase cloud
+│   ├── SheetDisplay.js             # Printable character sheet assembler
+│   ├── Sheet/                      # Individual sheet section components (read-only display)
+│   │   ├── AttributesBlock.js
+│   │   ├── SkillsBlock.js
+│   │   ├── WeaponsTable.js
+│   │   ├── ArmorTable.js
+│   │   ├── CyberwareTable.js
+│   │   ├── GearTable.js
+│   │   ├── LifestylesTable.js
+│   │   ├── SpellsTable.js
+│   │   ├── FociTable.js
+│   │   ├── VehiclesTable.js
+│   │   ├── DronesTable.js
+│   │   ├── CustomWeaponsTable.js
+│   │   ├── CustomVehiclesTable.js
+│   │   ├── CustomDecksTable.js
+│   │   ├── CyberdeckTable.js
+│   │   ├── ConditionMonitorBlock.js
+│   │   ├── ConditionMonitorBlockCyberDeck.js
+│   │   ├── PersonaConditionMonitor.js
+│   │   ├── VehicleConditionMonitor.js
+│   │   ├── DicePools.js
+│   │   ├── AllyTable.js
+│   │   ├── PhysicalAdeptPowers.js
+│   │   └── RunnerInfo.js
+│   ├── PriorityPanel.js            # SR3 priority system
+│   ├── PointBuyPanel.js            # SR2 point-buy system
+│   ├── AttributesPanel.js          # Attribute spending
+│   ├── SR2SkillsPanel.js           # SR2 skills (active/language/knowledge)
+│   ├── SR3SkillsPanel.js           # SR3 skills
+│   ├── MagicPanel.js               # Spells, foci, traditions, totems
+│   ├── OtakuPanel.js               # Otaku / complex forms
+│   ├── CyberwarePanel.js           # Cyberware + bioware
+│   ├── GearPanel.js                # Weapons, armor, gear, lifestyles
+│   ├── DeckingPanel.js             # Cyberdeck + programs
+│   ├── VehiclesPanel.js            # Vehicles + drones
+│   ├── ContactsPanel.js            # Contacts
+│   ├── KarmaDisplay.js             # Karma totals display
+│   ├── KarmaSkillAdvancement.js    # Post-chargen karma spend
+│   ├── ConditionMonitor.js         # Physical/stun monitor (editable)
+│   ├── LifestyleBuilderModal.js    # Lifestyle purchase modal
+│   ├── VehicleDesigner.js          # SR2 custom vehicle builder
+│   ├── SR3VehicleDesigner.js       # SR3 custom vehicle builder (Rigger 3 rules)
+│   ├── WeaponDesigner.js           # Custom weapon builder
+│   ├── WeaponModsModal.js          # Weapon mod picker modal
+│   ├── CyberdeckDesigner.js        # SR2 cyberdeck builder (VR2 rules)
+│   ├── MatrixCyberdeckDesigner.js  # SR3 + C² cranial cyberterminal designer
+│   ├── ProgrammingCalculator.js    # SR3 programming calculator (4 sub-tabs)
+│   ├── SR2ProgrammingCalculator.js # SR2 programming calculator (VR2 rules, 4 sub-tabs)
+│   ├── ProgramCalculatorModal.js   # Quick program time modal (older, still present)
+│   ├── AllySection.js              # Ally spirit section
+│   ├── EdgesFlawsPanel.js          # SR3 edges & flaws
+│   ├── FinalizedBox.js             # Post-finalization locked view
+│   ├── ChargenBox.js               # Running chargen point totals display
+│   ├── IdentityPanel.js            # Name, metatype, race, misc identity fields
+│   ├── SignInPopup.js              # Firebase auth UI
+│   ├── PublicSheetPage.js          # Shareable public sheet (read-only URL)
+│   └── firebase.js                 # Firebase app + analytics init
+├── data/
+│   ├── Books.json                  # All sourcebook codes, names, editions
+│   ├── SR2/                        # SR2 game data
+│   │   ├── Firearms.json
+│   │   ├── Gear.json
+│   │   ├── Cyberware.json
+│   │   ├── Bioware.json
+│   │   ├── Cyberdeck.json
+│   │   ├── Programs.json
+│   │   ├── VirtualRealityPrograms.json
+│   │   ├── Vehicles.json
+│   │   ├── VehicleMods.json
+│   │   ├── Drones.json
+│   │   ├── Skills.json
+│   │   ├── Spells.json
+│   │   ├── AdeptPowers.json
+│   │   ├── Totems.json
+│   │   ├── ComplexForms.json
+│   │   ├── LanguageSkills.json
+│   │   ├── OtakuSkills.json
+│   │   ├── Rigger2.json            # Rigger 2 vehicle/weapon data
+│   │   ├── ProgrammingRules.js     # SR2/VR2 programming helpers + data
+│   │   └── VR2CyberdeckDesign.js   # SR2 cyberdeck construction data
+│   └── SR3/                        # SR3 game data (parallel structure)
+│       ├── ActiveSkills.json
+│       ├── Firearms.json
+│       ├── Gear.json               # Includes Miscellaneous Components (sr3.302)
+│       ├── Cyberware.json
+│       ├── Bioware.json
+│       ├── Cyberdeck.json
+│       ├── CyberdeckParts.json
+│       ├── Programs.json
+│       ├── Vehicles.json
+│       ├── VehicleMods.json
+│       ├── VehicleGear.json
+│       ├── VehicleWeapons.json
+│       ├── Drones.json
+│       ├── Spells.json
+│       ├── AdeptPowers.json
+│       ├── Totems.json
+│       ├── EdgesAndFlaws.json
+│       ├── SSGIDEdgesFlaws.json
+│       ├── SSGLifestyleEdgesFlaws.json
+│       ├── Lifestyles.json
+│       ├── LanguageSkills.json
+│       ├── WeaponMods.json
+│       ├── MatrixCyberdeckDesign.js  # SR3 deck construction data
+│       ├── ProgrammingRules.js       # SR3 programming helpers + language data
+│       ├── Rigger3Chassis.js
+│       ├── Rigger3Mods.js
+│       ├── Rigger3PowerPlants.js
+│       ├── Rigger3VehicleWeapons.js
+│       ├── WeaponFrames.js
+│       ├── WeaponModifications.js
+│       └── WeaponOptions.js
+├── dice/
+│   ├── DiceContext.js              # React context for dice state
+│   ├── diceBoxManager.js           # @3d-dice/dice-box wrapper
+│   ├── rollSR.js                   # SR dice pool logic (count successes ≥ TN)
+│   └── useRollDice.js              # Hook: roll + show overlay
+├── hooks/
+│   └── useDicePreference.js        # 2D vs 3D dice preference
+└── vehicle/
+    ├── parseDat.js                 # Parser for .dat vehicle files
+    ├── evalExpr.js                 # Expression evaluator for vehicle formulas
+    └── vehicleData.js              # Parsed vehicle data cache
+```
+
+---
+
+## Architecture
+
+### State Management
+
+There is **no Redux or Zustand**. All character state lives in a single large `Character` object in `Dashboard.js` via `useState`. Every panel receives what it needs as props and calls a setter passed down from Dashboard.
+
+```js
+// Simplified shape of Character
+{
+  name, age, metatype, race, gender,
+  edition,                          // 'SR2' | 'SR3'
+  bookTogglesSR3: { cc, mits, sr3, mm, mat, r3, ... },
+  bookTogglesSR2: { sr2: true },
+  characterTabs: {                  // which optional tabs are enabled
+    VehicleDesigner, WeaponDesigner, CyberdeckDesigner, ProgrammingCalculator
+  },
+  attributes: { body, quickness, strength, charisma, intelligence, willpower, essence, magic, reaction },
+  skills: [...],
+  cyberware: [...],
+  bioware: [...],
+  gear: [...],
+  firearms: [...],
+  armor: [...],
+  vehicles: [...],
+  drones: [...],
+  spells: [...],
+  foci: [...],
+  contacts: [...],
+  programs: [...],
+  cyberdeck: {...},
+  lifestyles: [...],
+  customVehicles: [...],    // from Vehicle Designer
+  customWeapons: [...],     // from Weapon Designer
+  customDecks: [...],       // from Cyberdeck Designer
+  karma: 0,
+  nuyen: 0,
+  ...
+}
+```
+
+### Edition Switching
+
+`Edition` is a separate `useState` at the Dashboard level (not inside `Character`). When the user switches editions, both `Edition` state and `Character.Edition` are updated. Panels that differ between editions receive `Edition` as a prop and branch internally, or Dashboard renders a different component entirely:
+
+```jsx
+// Dashboard renders different components based on edition
+{Edition === 'SR2' ? <SR2ProgrammingCalculator /> : <ProgrammingCalculator />}
+{Edition === 'SR2' ? <SR2SkillsPanel /> : <SR3SkillsPanel />}
+```
+
+### Tab System
+
+Dashboard uses MUI `Tabs` with integer indexes. Tabs 0–12 are always present. Tabs 13–16 are **optional** — controlled by `Character.characterTabs` flags:
+
+| Index | Tab | Notes |
+|---|---|---|
+| 0 | Identity | Always shown |
+| 1 | Priorities (SR3) / Point Buy (SR2) | Edition-conditional |
+| 2 | Edges & Flaws (SR3 only) | |
+| 3 | Attributes | |
+| 4 | Skills | |
+| 5 | Otaku or Magic | Mutually exclusive, character-type conditional |
+| 6 | Cyberware | |
+| 7 | Gear | |
+| 8 | Decking | |
+| 9 | Vehicles | |
+| 10 | Contacts | |
+| 11 | Karma | |
+| 12 | Sheet Display | |
+| 13 | Vehicle Designer | Optional, flag-gated |
+| 14 | Weapon Designer | Optional, flag-gated |
+| 15 | Cyberdeck Designer | Optional, flag-gated |
+| 16 | Programming Calculator | Optional, flag-gated |
+
+### Data Format
+
+All JSON data files use a consistent item schema:
+
+```json
+{
+  "Name": "Ares Predator II",
+  "Cost": 450,
+  "Availability": "4/48hrs",
+  "Street Index": 1,
+  "Legal": "Restricted",
+  "BookPage": "sr3.285"
+}
+```
+
+`BookPage` format is `{bookCode}.{pageNumber}` — e.g. `sr3.285`, `cc.14`, `vr2.107`. The `bookCode` matches keys in `Books.json`. Items with unknown page numbers use `{code}.???` as a placeholder.
+
+Book toggles in the character (`bookTogglesSR2`, `bookTogglesSR3`) control which items appear in gear/cyberware/etc. pickers. Items are filtered client-side by checking whether their `BookPage` prefix is in the active toggle set.
+
+### Save / Load
+
+Three save mechanisms:
+1. **File export** — JSON download via `URL.createObjectURL` (the primary format)
+2. **localStorage** — 3 named slots
+3. **Firebase cloud save** — tied to Google auth via `SignInPopup`
+
+Character JSON includes the `edition` field so it restores correctly on load.
+
+### Analytics
+
+All GA4 events funnel through `src/analytics.js`. Never call `window.gtag` directly — always add a named export to that file. The wrapper silently swallows errors (blocked by ad blockers, etc.).
+
+Current events:
+
+| Event | Dimensions | Trigger |
+|---|---|---|
+| `character_saved` | `edition` | File export or localStorage save |
+| `character_loaded` | — | File or localStorage load |
+| `edition_changed` | `edition` | Edition dropdown change |
+| `character_finalized` | `edition`, `race` | Finalizing character |
+| `tab_viewed` | `tab_name` | Tab navigation |
+| `dice_rolled` | `dice_count` | Any dice roll |
+| `custom_vehicle_saved` | `edition` | Vehicle designer → Save |
+| `custom_weapon_saved` | `edition` | Weapon designer → Save |
+| `custom_deck_saved` | `edition` | Cyberdeck designer → Save |
+
+### Dice System
+
+Two dice modes selectable per user (`useDicePreference`):
+- **2D mode** — `@dice-roller/rpg-dice-roller`, results shown in `DiceResultOverlay`
+- **3D mode** — `@3d-dice/dice-box` (WebGL animated dice), managed by `diceBoxManager`
+
+`rollSR.js` implements Shadowrun dice pool logic: roll N d6, count successes (≥ TN), handle rule-of-six (6s reroll and add). The `useRollDice` hook is consumed by sheet blocks (`AttributesBlock`, `SkillsBlock`) to trigger rolls from the sheet.
+
+---
+
+## What's Working
+
+### Character Creation
+- Full SR2 point-buy and SR3 priority selection
+- All attributes, skills (active/language/knowledge), edges & flaws
+- Metatype, race, gender, identity fields
+- Karma tracking and post-chargen karma advancement (`KarmaSkillAdvancement`)
+
+### Cyberware & Gear
+- Cyberware and bioware (cyberware grades, essence costs)
+- Full gear browser with book toggles — weapons, armor, gear, lifestyles, vehicles, drones, programs
+- Weapon and vehicle mod modals
+- Lifestyle builder modal
+
+### Magic / Otaku
+- Spells, foci, traditions, totems for all SR2/SR3 traditions
+- Physical adept powers
+- Otaku complex forms and skills
+- Ally spirit section
+
+### Designers (optional tabs)
+- **Vehicle Designer** — SR2 rules + SR3 Rigger 3 rules (separate components, edition-conditional)
+- **Weapon Designer** — custom weapon builder with mod selection
+- **Cyberdeck Designer** — SR2 VR2 construction rules + SR3 Matrix book rules + SR3 C² cranial cyberterminal mode
+- **Programming Calculator (SR3)** — 4 sub-tabs: Utility/IC Programs, Frames & Agents, Worms, Command Sets. IC rating multiplier auto-fill. Programming language effects shown inline.
+- **Programming Calculator (SR2)** — 4 sub-tabs: Utility Programs (with upgrade mode + program prices), Frames (dumb/smart, attribute allocation, frame loading), Program Size Table, Command Sets (full VR2 rules). Source: VR2 pp.101–107.
+
+### Sheet Display
+- Printable sheet with all sections rendered: attributes, skills, dice pools, cyberware, bioware, gear, weapons, armor, vehicles, drones, spells, foci, lifestyles, condition monitors, ally, custom designs
+- Shareable public sheet via URL (`PublicSheetPage`)
+- Condition monitors (physical, stun, cyberdeck persona, vehicle)
+
+### Dice
+- Click-to-roll from AttributesBlock and SkillsBlock on the sheet
+- Roll dialog asks for TN and pool size
+- 2D (overlay) and 3D (WebGL) modes
+
+---
+
+## Known Incomplete / Broken
+
+### Data Page Numbers
+Many items have correct book codes but unknown page numbers (`???`). All functionality still works — these are display/reference gaps only.
+
+| Code | Book | Scope |
+|---|---|---|
+| `ssc.???` | Street Samurai Catalog | ~1,400+ cyberware/adept powers/firearms/gear |
+| `gm2.???` | The Grimoire 2nd Ed | 188 spells |
+| `fof.???` | Fields of Fire | ~60 gear/ammo/rocket items |
+| `rbb.???` | Rigger Black Box | 4 Sentinel Pod entries |
+
+### `SpellsWithCats.json` (SR2)
+Unused file at `src/data/SR2/SpellsWithCats.json`. Not imported anywhere. Can be safely deleted. Uses a different schema (capital `SR2.???` format) that predates the current convention.
+
+### `grm` vs `gm2`
+Both `grm` (The Grimoire) and `gm2` (The Grimoire 2nd Ed) exist in `Books.json`. Data uses `grm` for confirmed Grimoire content; 188 spells use `gm2` for unconfirmed Grimoire 2nd Ed content. These may overlap — needs reconciliation once Grimoire 2nd Ed OCR is available.
+
+### SR3VehicleDesigner
+Lives at `src/components/SR3VehicleDesigner.js` but is **not wired into Dashboard**. The generic `VehicleDesigner` at index 13 handles both editions. SR3VehicleDesigner exists as a standalone component — unclear whether it was intended as a replacement or an alternative entry point.
+
+### ProgramCalculatorModal
+`src/components/ProgramCalculatorModal.js` is an older quick-calc modal that predates `ProgrammingCalculator.js`. Still present in the codebase; its current usage scope is unclear.
+
+---
+
+## Key Design Decisions
+
+### Single large `Character` object in Dashboard
+Deliberately avoided Redux/Zustand to keep the codebase simple. All state passes as props. The downside is Dashboard.js is very large (~1,100 lines). Decision was made to live with this rather than introduce a state library.
+
+### Edition rendered as two separate component trees, not flags
+Rather than passing `edition` deep into every component and branching everywhere, edition-specific components (SR2SkillsPanel vs SR3SkillsPanel, SR2ProgrammingCalculator vs ProgrammingCalculator) are swapped at the Dashboard level. This keeps individual components clean but duplicates some structure.
+
+### Designer tabs are opt-in
+Vehicle Designer, Weapon Designer, Cyberdeck Designer, and Programming Calculator tabs are hidden by default and enabled via `Character.characterTabs` flags in the Identity panel. This prevents overwhelming new users.
+
+### Book toggles filter gear client-side
+Items are not split into separate files per book. Everything for an edition lives in one JSON file (e.g. `SR3/Gear.json`). Book toggles filter at render time by checking `item.BookPage` against the active book set. This makes adding new books easy (add items to the JSON, add the book to `Books.json`) but means large JSON files.
+
+### BookPage convention: `{code}.{page}`
+Page references format `sr3.285` / `vr2.107` / `ssc.???` serve double duty: they identify which book the item came from (for filtering) and provide the page citation for the user. The `???` placeholder keeps filtering working even when page numbers are unknown.
+
+### Analytics wrapper pattern
+`window.gtag` is never called directly. All calls go through named functions in `src/analytics.js`. This makes it easy to audit what's tracked, keeps event names consistent, and silently handles ad-blocker failures.
+
+### No TypeScript
+Project is plain JavaScript. Types are inferred by convention. If adding TypeScript, start with the data layer (`src/data/`) since schemas are well-defined.
+
+---
+
+## Active Branches (as of 2026-06-23)
+
+| Branch | Status |
+|---|---|
+| `main` | Production |
+| `feature/programming-calculator` | **Open PR #166** — SR2/SR3 programming calculators, cyberdeck designers, analytics events |
+| `feature/shareable-sheet-links` | Shareable public sheet — status unknown |
+| `feature/vehicle-designer` | Merged into main via PR #164 |
+| `RiggerAudit` | SR2 book data audit work — largely complete, may have residual commits |
+
+---
+
+## Source Books Implemented
+
+### SR2
+Core book, Virtual Realities 2.0 (VR2), Street Samurai Catalog (SSC), Shadowtech, CyberTechnology, Fields of Fire, The Grimoire, Rigger 2, Street Samurai Catalog 2nd Ed, Paradise Lost, NERPS: ShadowLore
+
+### SR3
+Core book, Cannon Companion, Magic in the Shadows, Man and Machine, Matrix, Rigger 3, State of the Art 2063/2064, Seattle Sourcebook, Target: Awakened Lands, Target: Wastelands, Year of the Comet, Sprawl Survival Guide, plus various sourcebooks and Neo-Anarchist Guide to Everything Else issues
+
+---
+
+## Running Locally
+
+```bash
+npm install
+npm start        # Vite dev server on localhost:5173
+npm test         # Jest test suite
+npm run build    # Production build
+```
+
+Firebase config is in `src/components/firebase.js`. Analytics and cloud save require the Firebase project to be configured — they fail silently in dev.

--- a/scripts/fix_aw_pages.py
+++ b/scripts/fix_aw_pages.py
@@ -1,0 +1,59 @@
+import json, re
+
+# Book page = PDF page - 1 (confirmed offset for Awakenings)
+# Mapping: name pattern -> book page
+PAGE_MAP = [
+    # aw.115
+    ('Blind Fighting',          'aw.115'),
+    ('Counterstrike',           'aw.115'),
+    ('Delay Damage',            'aw.115'),
+    # aw.116
+    ('Distance Strike',         'aw.116'),
+    ('Empathic Sense',          'aw.116'),
+    ('Enhanced Coordination',   'aw.116'),
+    ('Flexibility',             'aw.116'),
+    ('FreeFall',                'aw.116'),
+    # aw.117
+    ('Iron Will',               'aw.117'),
+    ('Magic Resistance',        'aw.117'),
+    ('Magic Sense',             'aw.117'),
+    ('Missile Mastery',         'aw.117'),
+    ('Nerve Strike',            'aw.117'),
+    ('Quick Draw',              'aw.117'),
+    # aw.118
+    ('Quick Strike',            'aw.118'),
+    ('Rapid Healing',           'aw.118'),
+    ('Rooting',                 'aw.118'),
+    ('Sixth Sense',             'aw.118'),
+    ('Smashing Blow',           'aw.118'),
+    # aw.119
+    ('Spell Shroud',            'aw.119'),
+    ('Temperature Tolerance',   'aw.119'),
+    ('Traceless Walk',          'aw.119'),
+]
+
+with open('src/data/SR2/AdeptPowers.json', 'r', encoding='utf-8-sig') as f:
+    powers = json.load(f)
+
+fixed = 0
+for power in powers:
+    if power.get('BookPage', '').strip() != 'aw.???':
+        continue
+    name = power['Name'].strip()
+    for pattern, page in PAGE_MAP:
+        if name.startswith(pattern):
+            power['BookPage'] = page
+            fixed += 1
+            break
+
+print(f"Fixed: {fixed}")
+remaining = sum(1 for p in powers if p.get('BookPage') == 'aw.???')
+print(f"Still aw.???: {remaining}")
+if remaining:
+    for p in powers:
+        if p.get('BookPage') == 'aw.???':
+            print(f"  UNMATCHED: {p['Name'].strip()}")
+
+with open('src/data/SR2/AdeptPowers.json', 'w', encoding='utf-8', newline='\n') as f:
+    json.dump(powers, f, indent=2, ensure_ascii=False)
+print("Done.")

--- a/scripts/fix_ssc.py
+++ b/scripts/fix_ssc.py
@@ -1,0 +1,165 @@
+import re
+
+with open('src/data/SR2/Gear.json', 'r', encoding='utf-8') as f:
+    content = f.read()
+
+mappings = [
+    ('Raecor Sting', 'fof.89'),
+    ('Walther Palm Pistol', 'fof.89'),
+    ('Streetline Special', 'fof.89'),
+    ('AET NN8[^0-9]', 'fof.89'),
+    ('AET Dealanach', 'fof.89'),
+    ('Ares.?Light.?Fire 70', 'fof.89'),
+    ('Beretta.?200ST', 'fof.89'),
+    ('Beretta.?101T', 'fof.89'),
+    ('Ceska.?vz.?120', 'fof.89'),
+    ('Colt.?American.?L36', 'fof.89'),
+    ('Executive Action', 'fof.89'),
+    ('Fichetti.?Security.?500a', 'fof.89'),
+    ('Fichetti.?Security.?500[^a]', 'fof.89'),
+    ('Seco LD.?120', 'fof.89'),
+    ('Ares.?Crusader', 'fof.89'),
+    ('Ceska.?Black.?Scorpion', 'fof.89'),
+    ('Ares.?Predator', 'fof.89'),
+    ('Browning.?Ultra.?Power', 'fof.89'),
+    ('Browning Max.?Power', 'fof.89'),
+    ('Colt.?Manhunter', 'fof.89'),
+    ('Hammerli.?610S', 'fof.89'),
+    ('Remington.?Roomsweeper', 'fof.89'),
+    ('Ruger.?Super.?Warhawk', 'fof.89'),
+    ('Defiance.?Super.?Shock', 'fof.89'),
+    ('Bracer\\b', 'fof.89'),
+    ('Gun Cane\\b', 'fof.89'),
+    ('Narcoject Pistol', 'fof.89'),
+    ('Narcoject Rifle', 'fof.89'),
+    ('Net Gun', 'fof.89'),
+    ('Yamaha Pulsar', 'fof.89'),
+    ('Tiffani.?Self.?Defender', 'fof.89'),
+    ('Tiffani.?Needler', 'fof.89'),
+    ('Walther PB.?120', 'fof.89'),
+    ('Fichetti Military XI Smart', 'fof.89'),
+    ('Fichetti Military XI\\b', 'fof.89'),
+    ('Fichetti Tiffani Needler', 'fof.89'),
+    ('Fichetti Executive Action', 'fof.89'),
+    ('Morrissey Elan', 'fof.89'),
+    ('Morrissey Alta', 'fof.89'),
+    ('Morrissey Elite', 'fof.89'),
+    ('Morrissey\\b', 'fof.89'),
+    ('Savalette Guardian', 'fof.89'),
+    ('Ares Viper', 'fof.89'),
+    # FoF page 90
+    ('H.?K.?HK.?227\\b', 'fof.90'),
+    ('HK.?227.?S\\b', 'fof.90'),
+    ('Ingram.?Warrior', 'fof.90'),
+    ('Uzi III\\b', 'fof.90'),
+    ('AET NN22', 'fof.90'),
+    ('Colt.?Cobra\\b', 'fof.90'),
+    ('Berretta.?Model.?70', 'fof.90'),
+    # FoF page 91
+    ('MGL.?12\\b', 'fof.91'),
+    ('MCGL.?6\\b', 'fof.91'),
+    ('Multi.Launcher', 'fof.91'),
+    ('Arbelast II MAW', 'fof.91'),
+    # FoF other pages
+    ('ArmTech Mini.?6', 'fof.47'),
+    ('ArmTech MGL', 'fof.47'),
+    ('Ingram Super.?Mach', 'fof.31'),
+    ('Colt M.?23\\b', 'fof.32'),
+    ('Ares Alpha', 'fof.33'),
+    ('Remington 990', 'fof.36'),
+    ('Franchi.?SPAS.?22', 'fof.37'),
+    ('Ares HV MP', 'fof.38'),
+    ('Great Dragon ATGM', 'fof.41'),
+    ('Ballista Multi.Role', 'fof.42'),
+    ('M.12 Man.Portable Mortar', 'fof.44'),
+    ('Light Military Armor', 'fof.54'),
+    ('Medium Military Armor', 'fof.54'),
+    ('Heavy Military Armor', 'fof.54'),
+    ('Military Helmet', 'fof.54'),
+    ('Rapier\\b', 'fof.81'),
+    ('Fineblade Knife', 'fof.88'),
+    ('Whip\\b', 'fof.88'),
+    # FoF page 95
+    ('Sony Beautiful Dreamer II', 'fof.95'),
+    ('Sony Beautiful Dreamer\\b', 'fof.95'),
+    ('Truman Paradiso', 'fof.95'),
+    ('Fuchi Dreamliner', 'fof.95'),
+    ('Fuchi RealSense.*MasterSim', 'fof.95'),
+    ('Fuchi RealSense.*Kosmos', 'fof.95'),
+    ('Truman Dreambox', 'fof.95'),
+    # FoF page 96
+    ('AZT Micro30', 'fof.96'),
+    ('Bionome Tridlink', 'fof.96'),
+    ('Fuchi.*Holo.Edit', 'fof.96'),
+    ('Fuchi.*I.C.U', 'fof.96'),
+    ('Kodak GAC.25', 'fof.96'),
+    ('Cable Signal Formatter', 'fof.96'),
+    ('Ares CyberMed', 'fof.96'),
+    ('Galil Ruach', 'fof.96'),
+    ('Holotank', 'fof.96'),
+    # FoF page 97
+    ('Sense Patch Injector', 'fof.97'),
+    ('Signal Peak Controller', 'fof.97'),
+    ('Truman Reality.500', 'fof.97'),
+    # FoF page 98
+    ('Body Mike', 'fof.98'),
+    ('Hand Mike', 'fof.98'),
+    ('Mike Stand', 'fof.98'),
+    ('Mike Boom', 'fof.98'),
+    ('Microcorder', 'fof.98'),
+    ('Minicorder', 'fof.98'),
+    ('Sprawl Blaster', 'fof.98'),
+    ('Sprawl Fuserr', 'fof.98'),
+    # FoF page 99
+    ('Data Codebreaker', 'fof.99'),
+    # SSC stats table page 111
+    ('Ares Monosword', 'ssc.111'),
+    ('Centurion Laser Axe', 'ssc.111'),
+    ('AZ.?150 Stun Baton', 'ssc.111'),
+    ('Forearm Snap Blades', 'ssc.111'),
+    ('Improved Hand Blades', 'ssc.111'),
+    ('Shock Glove', 'ssc.111'),
+    ('Ranger.X\\b', 'ssc.111'),
+    ('Tiffani Self.Defender', 'ssc.111'),
+    ('Enfield AS7', 'ssc.111'),
+    ('Defiance T.250', 'ssc.111'),
+    ('Mossberg.*CMDT', 'ssc.111'),
+    ('Sandler TMP', 'ssc.111'),
+    ('SCK.?Model.?100', 'ssc.111'),
+    ('Ingram.?Smartgun', 'ssc.111'),
+    ('Steyr.?AUG.?CSL', 'ssc.111'),
+    ('H.?K.?MP.?5TX', 'ssc.111'),
+    ('Beretta.?Model.?70\\b', 'ssc.111'),
+    ('Form.Fitting Body Armor', 'ssc.111'),
+    # SSC page 112
+    ('Ruger.?100\\b', 'ssc.112'),
+    ('Walther.?MA.?2100', 'ssc.112'),
+    ('Colt.?M22A2', 'ssc.112'),
+    ('H.?K.?G12A3z', 'ssc.112'),
+    ('Samopal.?vz.?88V', 'ssc.112'),
+    ('Ares.?MP.?LMG', 'ssc.112'),
+    ('Vindicator Minigun', 'ssc.112'),
+    ('Panther.?Assault.?Cannon', 'ssc.112'),
+    ('FN.?MAG', 'ssc.112'),
+    ('Stoner.?Ares.?M107', 'ssc.112'),
+]
+
+def fix(content, name_pat, new_page):
+    pattern = r'("Name":\s*"[^"]*' + name_pat + r'[^"]*"\s*(?:,\s*"[^"]*":\s*"[^"]*"\s*)*,\s*)"BookPage":\s*"ssc\.\?\?\?"'
+    replacement = r'\g<1>"BookPage": "' + new_page + '"'
+    return re.sub(pattern, replacement, content, flags=re.DOTALL|re.IGNORECASE)
+
+total = 0
+for pat, page in mappings:
+    before = content.count('"ssc.???"')
+    content = fix(content, pat, page)
+    after = content.count('"ssc.???"')
+    if before != after:
+        total += (before - after)
+
+print(f"Total fixed: {total}")
+print(f"Remaining ssc.???: {content.count(chr(34) + 'ssc.???' + chr(34))}")
+
+with open('src/data/SR2/Gear.json', 'w', encoding='utf-8', newline='') as f:
+    f.write(content)
+print("Done.")

--- a/src/components/OtakuPanel.js
+++ b/src/components/OtakuPanel.js
@@ -193,12 +193,17 @@ export default function OtakuPanel(props) {
   };
 
   // Book (Matrix p.137): free complex forms = Computer(Programming) skill × 50 Mp
+  // + 50 Mp per tribe resource level above Squatter (Matrix p.138)
+  const TRIBE_RESOURCE_LEVELS = ['Squatter', 'Low', 'Middle', 'High', 'Luxury'];
   const getFreeComplexFormMp = () => {
     const compSkill = (props.currentCharacter.skills ?? []).find(
       (s) => s.name === "Computer" || s.name === "Computer (Programming)"
     );
     const rating = compSkill?.rating ?? 0;
-    return rating * 50;
+    const tribeBonus = otakuTribe
+      ? Math.max(0, TRIBE_RESOURCE_LEVELS.indexOf(otakuTribe.resources)) * 50
+      : 0;
+    return rating * 50 + tribeBonus;
   };
 
   const handlePathChange = (event) => {
@@ -491,7 +496,17 @@ export default function OtakuPanel(props) {
             <div><strong>Otaku Path:</strong> <em>{props.currentCharacter.otakuPath}</em>: {OtakuPathInfo[props.currentCharacter.otakuPath]} </div>
             <div><strong>Hacking Pool:</strong> {hackingPool}</div>
             <div><strong>Starting Channel Points:</strong> {MPCP} (= MPCP; distribute among 5 channels)</div>
-            <div><strong>Free Complex Forms (char gen):</strong> {getFreeComplexFormMp()} Mp (Computer(Programming) × 50)</div>
+            <div><strong>Free Complex Forms (char gen):</strong> {getFreeComplexFormMp()} Mp
+              {(() => {
+                const compSkill = (props.currentCharacter.skills ?? []).find(s => s.name === 'Computer' || s.name === 'Computer (Programming)');
+                const rating = compSkill?.rating ?? 0;
+                const tribeLevel = otakuTribe ? Math.max(0, TRIBE_RESOURCE_LEVELS.indexOf(otakuTribe.resources)) : 0;
+                const tribeBonus = tribeLevel * 50;
+                return tribeBonus > 0
+                  ? ` (skill ${rating} × 50 + ${tribeBonus} tribe bonus)`
+                  : ` (Computer(Programming) × 50)`;
+              })()}
+            </div>
             <h3>Complex Forms</h3>
             <div>
                <Modal


### PR DESCRIPTION
## Summary
- Tribe resource level above Squatter now grants +50 Mp per level to the free complex form allowance at chargen (Matrix p.138): Low +50, Middle +100, High +150, Luxury +200
- Display label updates to show the breakdown when a bonus is active: `skill 6 × 50 + 100 tribe bonus`
- No tribe or Squatter-level tribe: unchanged behaviour

## Test plan
- [ ] Create an SR3 Otaku character with Computer (Programming) skill 6
- [ ] Confirm free complex forms shows 300 Mp with no tribe
- [ ] Register a tribe at Middle resources — confirm display updates to `400 Mp (skill 6 × 50 + 100 tribe bonus)`
- [ ] Change tribe to Luxury — confirm 500 Mp
- [ ] Leave tribe — confirm reverts to 300 Mp

🤖 Generated with [Claude Code](https://claude.com/claude-code)