### PR TITLE
Fix edition switch and priority race dropdown persistence

### DIFF
--- a/src/components/IdentityPanel.js
+++ b/src/components/IdentityPanel.js
@@ -19,9 +19,11 @@ export default function IdentityPanel(props) {
         setLocalEdition(event.target.checked);
         if(event.target.checked){
             props.ChangeEdition('SR3');
+            setBookStates(props.characterBooks3);
         }else{
             props.ChangePowerLevel(2);
             props.ChangeEdition('SR2');
+            setBookStates(props.characterBooks2);
         }
     }
     const [LocalMethod, setLocalMethod] = React.useState((props.CGMethod === 'pointbuy'?true:false));

--- a/src/components/PriorityPanel.js
+++ b/src/components/PriorityPanel.js
@@ -293,16 +293,23 @@ export default function PriorityPanel(props) {
 
   const handleChangePriorityRace = (newPriority) => {
     setPriorityRace(newPriority);
+    let firstRace;
     if(props.moreMetahumansOption === true){
-      setAvailableRaces(prorityChart[props.Edition]['MMrace'][newPriority]);
-      setRace(prorityChart[props.Edition]['MMrace'][newPriority][0]);
-      props.ChangeRaceChoices(prorityChart[props.Edition]['MMrace'][newPriority]);
+      const races = prorityChart[props.Edition]['MMrace'][newPriority];
+      firstRace = races[0];
+      setAvailableRaces(races);
+      setRace(firstRace);
+      props.ChangeRaceChoices(races);
     }else{
-      setAvailableRaces(prorityChart[props.Edition]['race'][newPriority]);
-      setRace(prorityChart[props.Edition]['race'][newPriority][0]);
-      props.ChangeRaceChoices(prorityChart[props.Edition]['race'][newPriority]);
+      const races = prorityChart[props.Edition]['race'][newPriority];
+      firstRace = races[0];
+      setAvailableRaces(races);
+      setRace(firstRace);
+      props.ChangeRaceChoices(races);
     }
-    
+    props.ChangeRace(firstRace);
+    const bonuses = prorityChart[props.Edition].raceBonuses[firstRace];
+    if (bonuses) props.ChangeRaceBonuses(bonuses);
   };
 
   const handleChangePriorityAttributes = (newPriority) => {

--- a/src/components/SR3SkillsPanel.js
+++ b/src/components/SR3SkillsPanel.js
@@ -142,7 +142,10 @@ function SR3SkillsPanel({
   };
 
   const handleKnowledgeCategoryChange = (event) => {
-    setKnowledgeSelectedCategory(event.target.value);
+    const cat = event.target.value;
+    setKnowledgeSelectedCategory(cat);
+    setKnowledgeNewSkill(skillsData[cat][0].name);
+    setKnowledgeSelectedSpecialization("");
   };
 
   //Handle Skill Change events


### PR DESCRIPTION
## Summary

Two related bugs fixed in Identity and Priorities tabs.

### Bug 1 — Edition switch didn't reset book checkboxes (IdentityPanel.js)
When toggling SR2↔SR3, `bookStates` (the local state driving book checkboxes) was initialized once on mount and never updated. Switching editions showed the new edition's books but all checkboxes appeared unchecked, and `ChangeAllowedBooks` was sending stale keys to Dashboard. Fix: `handleSwitchEd` now calls `setBookStates(props.characterBooks3)` or `setBookStates(props.characterBooks2)` to reset checkboxes to the correct edition's saved toggles.

### Bug 2 — Race dropdown reset on tab navigation and didn't default on drag (PriorityPanel.js)
`handleChangePriorityRace` updated local `Race` state and `AvailableRaces` on drag, but never called `props.ChangeRace()` or `props.ChangeRaceBonuses()`. Because `CustomTabPanel` fully unmounts children when inactive, `Race` re-initialised from `props.Race` (= `Character.race`) on every tab switch — which was always the stale value. Fix: added `props.ChangeRace(firstRace)` and `props.ChangeRaceBonuses(bonuses)` to match the existing `props.ChangeMagic()` call already present in `handleChangePriorityMagic`.

## Test plan
- [ ] Switch edition SR2 → SR3: SR3 core books should be checked by default
- [ ] Switch edition SR3 → SR2: SR2 core book should be checked, SR3 books gone
- [ ] Drag Race priority to C (SR3): Race dropdown immediately shows Troll
- [ ] Navigate to another tab and back: Race dropdown still shows Troll
- [ ] Drag Magic priority from E to B: Magic dropdown immediately shows Physical Adept
- [ ] Navigate away and back: Magic dropdown still shows Physical Adept

🤖 Generated with [Claude Code](https://claude.com/claude-code)