### PR TITLE
Fix React hooks-order crash when finalizing a character

### DIFF
--- a/src/components/KarmaSkillAdvancement.js
+++ b/src/components/KarmaSkillAdvancement.js
@@ -107,21 +107,12 @@ export default function KarmaSkillAdvancement({
   const [customAmount, setCustomAmount]   = useState(1);
   const [customConfirm, setCustomConfirm] = useState(false);
 
-  if (step !== 'finalized') return null;
-
-  const getAttrRating = (acronym) => {
-    if (!acronym || !characterAttributes) return null;
-    const name = ATTR_ACRONYM[acronym] ?? acronym;
-    return (parseInt(characterAttributes[name]) || 0) +
-           (parseInt(raceBonuses?.[name]) || 0);
-  };
-
   // ── Skill data for "add new skill" ──────────────────────────────────
   const rawSkills = Edition === 'SR3'
     ? allActiveSkills[`../data/SR3/ActiveSkills.json`]?.default
     : allSkillsData[`../data/SR2/Skills.json`]?.default;
 
-  // SR2 Skills.json is an object keyed by name; SR3 is an array of objects grouped by category
+  // useMemo must be called before any early return (Rules of Hooks)
   const flatSkillList = useMemo(() => {
     if (!rawSkills) return [];
     // SR3: object keyed by category, each value is an array of skill objects
@@ -132,6 +123,8 @@ export default function KarmaSkillAdvancement({
     }
     return values; // SR2
   }, [rawSkills, Edition]);
+
+  if (step !== 'finalized') return null;
 
   const existingSkillNames = new Set(skills.map((s) => s.name));
   const availableNewSkills = flatSkillList.filter(


### PR DESCRIPTION
## Summary
- `KarmaSkillAdvancement` had a `useMemo` placed **after** an early return (`if (step !== 'finalized') return null`)
- React requires hooks to be called in the same order on every render — the early return meant `useMemo` was skipped when `step === 'chargen'`, then called when `step` changed to `'finalized'`, causing error #310 (hook count mismatch)
- Fix: moved the `useMemo` and its `rawSkills` setup **before** the early return so hook count is constant, then moved the early return to after all hooks

## Test plan
- [ ] Create a character, fill in all tabs, then click the Finalize button in Karma Display
- [ ] Verify no React error is thrown and the character transitions to finalized state correctly
- [ ] Verify Karma Skill Advancement panel renders after finalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)