### PR TITLE
Fix cross-edition item bleed in Gear/Cyberware/Vehicles and book state bugs

### DIFF
--- a/src/components/CyberwarePanel.js
+++ b/src/components/CyberwarePanel.js
@@ -1,5 +1,12 @@
 ﻿import React, { useState, useEffect } from 'react';
 import FilteredMenuItem from './FilteredMenuItem';
+import AllBooks from '../data/Books.json';
+
+const wrongEdition = (bookCode, edition) => {
+  if (!bookCode) return false;
+  const b = AllBooks[bookCode];
+  return b?.edition && b.edition !== edition;
+};
 import SearchableSelect from './SearchableSelect';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
@@ -291,15 +298,19 @@ const handleCyberOrBioChange = (event) => {
           value={NewCyberwareIndex}
           onChange={handleCyberwareChange}
           label={SelectedCyberwareCategory}
-          renderItem={(cyber, i) => (
-            <FilteredMenuItem
-              allowed={props.BooksFilter.includes(cyber.BookPage.split('.')[0])}
-              bookCode={cyber.BookPage.split('.')[0]}
-              key={i} value={i}
-            >
-              {cyber.Name} - Essence Cost: {cyber.EssCost}
-            </FilteredMenuItem>
-          )}
+          renderItem={(cyber, i) => {
+            const bookCode = cyber.BookPage.split('.')[0];
+            if (wrongEdition(bookCode, props.Edition)) return null;
+            return (
+              <FilteredMenuItem
+                allowed={props.BooksFilter.includes(bookCode)}
+                bookCode={bookCode}
+                key={i} value={i}
+              >
+                {cyber.Name} - Essence Cost: {cyber.EssCost}
+              </FilteredMenuItem>
+            );
+          }}
           style={{ minWidth: 650 }}
         />
         <br/><br/>
@@ -393,15 +404,19 @@ const handleCyberOrBioChange = (event) => {
       value={NewBiowareIndex}
       onChange={handleBiowareChange}
       label={BiowareSelectedCategory}
-      renderItem={(bio, i) => (
-        <FilteredMenuItem
-          allowed={props.BooksFilter.includes(bio.BookPage.split('.')[0])}
-          bookCode={bio.BookPage.split('.')[0]}
-          key={i} value={i}
-        >
-          {bio.Name} - BioIndex Cost: {bio.BioIndex}
-        </FilteredMenuItem>
-      )}
+      renderItem={(bio, i) => {
+        const bookCode = bio.BookPage.split('.')[0];
+        if (wrongEdition(bookCode, props.Edition)) return null;
+        return (
+          <FilteredMenuItem
+            allowed={props.BooksFilter.includes(bookCode)}
+            bookCode={bookCode}
+            key={i} value={i}
+          >
+            {bio.Name} - BioIndex Cost: {bio.BioIndex}
+          </FilteredMenuItem>
+        );
+      }}
       style={{ minWidth: 650 }}
     />
     )}

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -456,16 +456,17 @@ export default function BasicTabs() {
   };
 
   const handleChangeAllowedBooks = (books) => {
+    const checkedBooks = Object.keys(books).filter(k => books[k]);
     if (Edition === "SR3") {
       setCharacter((prevCharacter) => ({
         ...prevCharacter,
-        allowedBooks: Object.keys(books),
+        allowedBooks: checkedBooks,
         bookTogglesSR3: books,
       }));
     } else if (Edition === "SR2") {
       setCharacter((prevCharacter) => ({
         ...prevCharacter,
-        allowedBooks: Object.keys(books),
+        allowedBooks: checkedBooks,
         bookTogglesSR2: books,
       }));
     }
@@ -660,6 +661,7 @@ export default function BasicTabs() {
 
   const handleLoadCharacter = (characterData) => {
     setCharacter(characterData);
+    if (characterData.Edition) setEdition(characterData.Edition);
   };
 
   const displayBox = () => {

--- a/src/components/GearPanel.js
+++ b/src/components/GearPanel.js
@@ -1,6 +1,13 @@
 ﻿import { MenuItem } from '@mui/material';
 import React, { useState } from 'react';
 import FilteredMenuItem from './FilteredMenuItem';
+import AllBooks from '../data/Books.json';
+
+const wrongEdition = (bookCode, edition) => {
+  if (!bookCode) return false;
+  const b = AllBooks[bookCode];
+  return b?.edition && b.edition !== edition;
+};
 import SearchableSelect from './SearchableSelect';
 import InputLabel from '@mui/material/InputLabel';
 import Button from '@mui/material/Button';
@@ -118,6 +125,7 @@ export default function GearPanel(props) {
 
     const renderGearItem = (gear, originalIndex) => {
       const bookCode = gear.BookPage?.split('.')[0];
+      if (wrongEdition(bookCode, props.Edition)) return null;
       const inDeckCategory = deckCategories.includes(SelectedGearCategory);
       const suppressedByVr2 = inDeckCategory && vr2Active && bookCode === 'sr2';
       const allowed = !suppressedByVr2 &&
@@ -151,6 +159,7 @@ export default function GearPanel(props) {
         getLabel={(item) => `${item.Name} (${item._category})`}
         renderItem={(item, originalIndex) => {
           const bookCode = item.BookPage?.split('.')[0];
+          if (wrongEdition(bookCode, props.Edition)) return null;
           const suppressedByVr2 = deckCategories.includes(item._category) && vr2Active && bookCode === 'sr2';
           const allowed = !suppressedByVr2 && (!item.BookPage || props.BooksFilter.includes(bookCode));
           return (

--- a/src/components/VehiclesPanel.js
+++ b/src/components/VehiclesPanel.js
@@ -1,5 +1,12 @@
 ﻿import React, { useState } from 'react';
 import FilteredMenuItem from './FilteredMenuItem';
+import AllBooks from '../data/Books.json';
+
+const wrongEdition = (bookCode, edition) => {
+  if (!bookCode) return false;
+  const b = AllBooks[bookCode];
+  return b?.edition && b.edition !== edition;
+};
 import SearchableSelect from './SearchableSelect';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
@@ -310,15 +317,19 @@ export default function VehiclesPanel(props) {
       onChange={handleVehicleChange}
       label="Vehicles"
       getLabel={(v) => v.name}
-      renderItem={(vehicle, i) => (
-        <FilteredMenuItem
-          allowed={props.BooksFilter.includes(vehicle['Book.Page'].split('.')[0])}
-          bookCode={vehicle['Book.Page'].split('.')[0]}
-          key={i} value={i}
-        >
-          {vehicle.name}
-        </FilteredMenuItem>
-      )}
+      renderItem={(vehicle, i) => {
+        const bookCode = vehicle['Book.Page'].split('.')[0];
+        if (wrongEdition(bookCode, props.Edition)) return null;
+        return (
+          <FilteredMenuItem
+            allowed={props.BooksFilter.includes(bookCode)}
+            bookCode={bookCode}
+            key={i} value={i}
+          >
+            {vehicle.name}
+          </FilteredMenuItem>
+        );
+      }}
       style={{ minWidth: 650, marginTop: 20 }}
     />
 
@@ -349,15 +360,19 @@ export default function VehiclesPanel(props) {
         onChange={handleDroneChange}
         label="Drones"
         getLabel={(d) => d.name}
-        renderItem={(drone, i) => (
-          <FilteredMenuItem
-            allowed={props.BooksFilter.includes(drone['Book.Page'].split('.')[0])}
-            bookCode={drone['Book.Page'].split('.')[0]}
-            key={i} value={i}
-          >
-            {drone.name}
-          </FilteredMenuItem>
-        )}
+        renderItem={(drone, i) => {
+          const bookCode = drone['Book.Page'].split('.')[0];
+          if (wrongEdition(bookCode, props.Edition)) return null;
+          return (
+            <FilteredMenuItem
+              allowed={props.BooksFilter.includes(bookCode)}
+              bookCode={bookCode}
+              key={i} value={i}
+            >
+              {drone.name}
+            </FilteredMenuItem>
+          );
+        }}
         style={{ minWidth: 650 }}
       />
 


### PR DESCRIPTION
## Summary
- **Edition not set on character load** — `handleLoadCharacter` never called `setEdition`, so loading an SR3 save left the app thinking it was SR2. Book states were then written to the wrong edition's slot (`bookTogglesSR2` instead of `bookTogglesSR3`)
- **Unchecked books leaking into `allowedBooks`** — `Object.keys(books)` returned every key regardless of `true`/`false` value, so unchecked books still appeared in `allowedBooks` and showed their items as enabled. Now filtered to only checked keys
- **SR2 items visible in SR3 gear/cyberware/vehicle lists** — The shared `Gear.json`, `Cyberware.json`, and `Vehicles.json` data files contain items from both edition's books. Items whose source book belongs to a different edition are now completely hidden (not just greyed-out). Same-edition unchecked-book items continue to show as greyed-out disabled entries. Fan/conversion books (no edition tag) are unaffected

## Files changed
- `Dashboard.js` — sync `Edition` state on character load; filter `allowedBooks` to checked-only
- `GearPanel.js` — hide cross-edition items in category picker and global search
- `CyberwarePanel.js` — hide cross-edition cyberware and bioware items
- `VehiclesPanel.js` — hide cross-edition vehicles and drones

## Test plan
- [ ] Load an SR3 character save — verify the book checkboxes show SR3 books checked, not SR2 books
- [ ] In SR3 mode, open Gear and verify no SR2-sourced items appear (e.g. items with `sr2.xxx` BookPage should be gone)
- [ ] In SR3 mode, open Cyberware and verify same
- [ ] Switch to SR2 mode and verify SR3 items are hidden there too
- [ ] Uncheck a book (e.g. Cannon Companion) — verify those items go grey but don't disappear from `allowedBooks` when another book is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)