### PR TITLE
Fix Google Analytics tag ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BMGB9T4RYD"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-FC158GDTHC"></script>
   <script src="https://www.gstatic.com/firebasejs/ui/6.1.0/firebase-ui-auth.js"></script>
   <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/6.1.0/firebase-ui-auth.css" />
   <script>
@@ -11,7 +11,7 @@
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
-    gtag('config', 'G-BMGB9T4RYD');
+    gtag('config', 'G-FC158GDTHC');
   </script>
   <meta charset="utf-8" />
   <link rel="icon" href="/favicon.ico" />

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BMGB9T4RYD"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-FC158GDTHC"></script>
   <script src="https://www.gstatic.com/firebasejs/ui/6.1.0/firebase-ui-auth.js"></script>
   <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/6.1.0/firebase-ui-auth.css" />
   <script>
@@ -11,7 +11,7 @@
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
-    gtag('config', 'G-BMGB9T4RYD');
+    gtag('config', 'G-FC158GDTHC');
   </script>
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/src/components/firebase.js
+++ b/src/components/firebase.js
@@ -10,7 +10,7 @@ const firebaseConfig = {
     storageBucket: "charactergeneratordb.firebasestorage.app",
     messagingSenderId: "163713762253",
     appId: "1:163713762253:web:13c30aae130d1b69c1ba84",
-    measurementId: "G-6K5NKQLHBJ"
+    measurementId: "G-FC158GDTHC"
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- Corrects GA tag ID to `G-FC158GDTHC` in all three locations:
  - `index.html` (was `G-BMGB9T4RYD`)
  - `public/index.html` (was `G-BMGB9T4RYD`)
  - `src/components/firebase.js` measurementId (was `G-6K5NKQLHBJ`)

## Test plan
- [ ] Verify GA4 events appear in the correct property after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)