### PR TITLE
Show linked attribute on SR3 active skill picker and list

### DIFF
--- a/src/components/SR3SkillsPanel.js
+++ b/src/components/SR3SkillsPanel.js
@@ -538,6 +538,11 @@ function SR3SkillsPanel({
                 </NativeSelect>
               </FormControl>
             )}
+            {newSkillAttribute && (
+              <span style={{ marginLeft: "12px", fontSize: "0.85rem", color: "#666", verticalAlign: "middle" }}>
+                Linked attribute: <strong>{AcronymToAttribute[newSkillAttribute] ?? newSkillAttribute}</strong>
+              </span>
+            )}
             <>
               <FormControl style={{ width: "400px", marginLeft: "20px" }}>
                 <InputLabel id="specialization-label" shrink>
@@ -744,11 +749,10 @@ function SR3SkillsPanel({
                   <ListItemText
                     primary={
                       skill.specialization
-                        ? `${skill.name} (${skill.rating - 1}) ->  ${
-                            skill.specialization
-                          } (${skill.rating + 1}) Cost:[${skill.cost}]`
+                        ? `${skill.name} (${skill.rating - 1}) ->  ${skill.specialization} (${skill.rating + 1}) Cost:[${skill.cost}]`
                         : `${skill.name} (${skill.rating}) Cost:[${skill.cost}]`
                     }
+                    secondary={AcronymToAttribute[skill.attribute] ?? skill.attribute}
                   />
                   <Button
                     color="primary"

--- a/src/components/SR3SkillsPanel.js
+++ b/src/components/SR3SkillsPanel.js
@@ -81,7 +81,7 @@ function SR3SkillsPanel({
     )
   );
   const [newSkill, setNewSkill] = useState("Assault Rifles");
-  const [newSkillAttribute, setNewSkillAttribute] = useState("INT");
+  const [newSkillAttribute, setNewSkillAttribute] = useState(skillsData["Combat skills"][0].attribute);
 
   //Knowledge Skills
   const [selectedKnowledgeSpecialization, setKnowledgeSelectedSpecialization] = useState("");
@@ -170,7 +170,7 @@ function SR3SkillsPanel({
   const handleCategoryChange = (event) => {
     setSelectedCategory(event.target.value);
     setNewSkill(skillsData[event.target.value][0].name);
-    setNewSkillAttribute(skillsData[event.target.value][0].name.attribute);
+    setNewSkillAttribute(skillsData[event.target.value][0].attribute);
     setSelectedSpecialization("");
   };
 


### PR DESCRIPTION
## Summary
Two small additions to make the linked attribute visible in the SR3 Skills panel:

- **Skill picker**: a small inline label appears next to the skill dropdown — "Linked attribute: **Quickness**" — updating live as you change the selected skill
- **Skill list**: each added active skill shows its attribute (e.g. "Quickness") as secondary text beneath the skill name

Knowledge and Language skills are always INT so no change needed there.

## Test plan
- [ ] SR3 character → Skills tab: select different active skills and confirm the attribute label updates
- [ ] Add a skill and confirm the attribute appears in the list beneath it

🤖 Generated with [Claude Code](https://claude.com/claude-code)