### PR TITLE
Recalculate SR3 active skill costs when attributes change

### DIFF
--- a/src/components/SR3SkillsPanel.js
+++ b/src/components/SR3SkillsPanel.js
@@ -130,6 +130,22 @@ function SR3SkillsPanel({
     setSelectedManeuvers((prev) => prev.filter((m) => m !== maneuver));
   };
 
+  // Recalculate active skill costs whenever attributes or race bonuses change
+  useEffect(() => {
+    setSelectedSkills(prev => {
+      const recalculated = prev.map(skill => {
+        const attrName = AcronymToAttribute[skill.attribute] ?? skill.attribute;
+        const attrVal = (parseInt(currentCharacter.attributes?.[attrName]) || 0)
+                      + (parseInt(currentCharacter.raceBonuses?.[attrName]) || 0);
+        const rating = parseInt(skill.rating);
+        const costDiff = rating - attrVal;
+        const cost = costDiff > 0 ? rating + costDiff : rating;
+        return cost === skill.cost ? skill : { ...skill, cost };
+      });
+      return recalculated.some((s, i) => s !== prev[i]) ? recalculated : prev;
+    });
+  }, [currentCharacter.attributes, currentCharacter.raceBonuses]);
+
   useEffect(() => {
     //Actually remove the skills when they are deleted.
     onUpdateSkills([


### PR DESCRIPTION
## Summary
Skill costs were calculated once at add-time and never updated. If you added a skill with a low attribute then raised the attribute (or vice versa), the displayed cost and the points-spent total stayed wrong.

Added a `useEffect` that watches `currentCharacter.attributes` and `currentCharacter.raceBonuses` and re-runs the same formula used at add-time:

```
cost = rating + max(0, rating - (attrValue + raceBonus))
```

Uses a functional `setSelectedSkills` update so it:
- Avoids stale closure on the skills array
- Only triggers the downstream `onUpdateSkills` effect when a cost actually changed (returning the same array reference when nothing changed)

## Test plan
- [ ] SR3 character → set Strength to 1 → add Unarmed Combat at rating 6 → cost shows 11
- [ ] Raise Strength to 6 → cost updates to 6 automatically
- [ ] Lower Strength back to 1 → cost returns to 11
- [ ] Skills with rating ≤ attribute show no extra cost penalty

🤖 Generated with [Claude Code](https://claude.com/claude-code)